### PR TITLE
Add Eq trait bound in sub_array_equals

### DIFF
--- a/circuit/src/arrays.nr
+++ b/circuit/src/arrays.nr
@@ -1,6 +1,6 @@
 use dep::std;
 
-pub fn sub_array_equals<T, N, M>(subarray: [T; N], array: [T; M], start_index: Field) -> bool {
+pub fn sub_array_equals<T, N, M>(subarray: [T; N], array: [T; M], start_index: Field) -> bool where T: Eq {
     assert(start_index as u64 + N <= M, "Invalid range");
     let mut result = true;
     for i in 0..N {


### PR DESCRIPTION
This is probably related to the new noir version. Without it - noir complains that `T` is not necessarily `Eq`