### PR TITLE
Set pool to forks in vitest config

### DIFF
--- a/packages/noir-ethereum-api/vitest.config.ts
+++ b/packages/noir-ethereum-api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    pool: "forks",
+  },
+});


### PR DESCRIPTION
This seems to fix the issue for me. I've written a script that runs tests N times sequentially.
It hang before and does not hang now. Perf seems to be the same.
Here are the docs: https://vitest.dev/config/#pool-1-0-0
I didn't dig deep enough as to discover the underlying issue, but it seems that some library we use doesn't like it when it's being run in threads. Probably someone forgot some synchronisation, but I don't think it's worth out time now to look for it.