### PR TITLE
Fix noir warnings

### DIFF
--- a/circuit/src/arrays.nr
+++ b/circuit/src/arrays.nr
@@ -9,12 +9,6 @@ pub fn sub_array_equals<T, N, M>(subarray: [T; N], array: [T; M], start_index: F
     result
 }
 
-fn alter_array<N>(array: [u8; N]) -> [u8; N] {
-    let mut copy = array.map(|x| x);
-    copy[0] = std::wrapping_add(copy[0], 1);
-    copy
-}
-
 #[test]
 fn test_sub_array_equals() {
     let a: [Field; 3] = [2, 3, 4];

--- a/circuit/src/get_account.nr
+++ b/circuit/src/get_account.nr
@@ -15,7 +15,11 @@ struct AccountWithProof {
 #[oracle(get_account)]
 unconstrained fn get_account_oracle(_block_no: Field, _address: [u8; 20]) -> AccountWithProof {}
 
-unconstrained fn get_account(block_no: Field, address: [u8; 20], state_root: [u8; proof::KEY_LENGTH]) -> AccountWithProof {
+unconstrained pub(crate) fn get_account(
+    block_no: Field,
+    address: [u8; 20],
+    state_root: [u8; proof::KEY_LENGTH]
+) -> AccountWithProof {
     let account = get_account_oracle(block_no, address);
     let trie_proof = proof::TrieProof { key: account.key, proof: account.proof, depth: account.depth, value: account.value };
     assert(trie_proof.verify_state_root(state_root));

--- a/circuit/src/get_header.nr
+++ b/circuit/src/get_header.nr
@@ -1,7 +1,8 @@
 use dep::proof::rlp::{decode1, RLP_List};
 use dep::std::test::OracleMock;
 use dep::std::hash::keccak256;
-use crate::arrays::{sub_array_equals, alter_array};
+use dep::std::wrapping_add;
+use crate::arrays::{sub_array_equals};
 
 global MAX_HEADER_RLP_SIZE = 708;
 global HEADER_FIELDS_COUNT = 17;
@@ -23,7 +24,7 @@ struct BlockHeaderPartial {
 #[oracle(get_header)]
 unconstrained fn get_header_oracle(_block_no: Field) -> BlockHeaderPartial {}
 
-unconstrained fn get_header(block_no: Field) -> BlockHeaderPartial {
+unconstrained pub(crate) fn get_header(block_no: Field) -> BlockHeaderPartial {
     let header = get_header_oracle(block_no);
     let rlp_list:RLP_List<HEADER_FIELDS_COUNT> = decode1(header.encoded);
     assert(
@@ -86,9 +87,15 @@ global encoded_len: Field = 515;
 
 global blockPartial = BlockHeaderPartial { stateRoot, transactionsRoot, receiptsRoot, number, hash, encoded_len, encoded };
 
+fn alter_array<N>(array: [u8; N]) -> [u8; N] {
+    let mut copy = array.map(|x| x);
+    copy[0] = wrapping_add(copy[0], 1);
+    copy
+}
+
 #[test]
 fn test_get_header_success() {
-    OracleMock::mock("get_header").returns(blockPartial);
+    let _ = OracleMock::mock("get_header").returns(blockPartial);
     assert(get_header(0).stateRoot == stateRoot);
 }
 
@@ -96,7 +103,7 @@ fn test_get_header_success() {
 fn test_get_header_invalid_state_root() {
     let stateRoot = alter_array(stateRoot);
     let blockPartial = BlockHeaderPartial { stateRoot, transactionsRoot, receiptsRoot, number, hash, encoded_len, encoded };
-    OracleMock::mock("get_header").returns(blockPartial);
+    let _ = OracleMock::mock("get_header").returns(blockPartial);
     assert(get_header(0).stateRoot == stateRoot);
 }
 
@@ -104,7 +111,7 @@ fn test_get_header_invalid_state_root() {
 fn test_get_header_invalid_transactions_root() {
     let transactionsRoot = alter_array(transactionsRoot);
     let blockPartial = BlockHeaderPartial { stateRoot, transactionsRoot, receiptsRoot, number, hash, encoded_len, encoded };
-    OracleMock::mock("get_header").returns(blockPartial);
+    let _ = OracleMock::mock("get_header").returns(blockPartial);
     assert(get_header(0).stateRoot == stateRoot);
 }
 
@@ -112,7 +119,7 @@ fn test_get_header_invalid_transactions_root() {
 fn test_get_header_invalid_receipt_root() {
     let receiptsRoot = alter_array(receiptsRoot);
     let blockPartial = BlockHeaderPartial { stateRoot, transactionsRoot, receiptsRoot, number, hash, encoded_len, encoded };
-    OracleMock::mock("get_header").returns(blockPartial);
+    let _ = OracleMock::mock("get_header").returns(blockPartial);
     assert(get_header(0).stateRoot == stateRoot);
 }
 
@@ -120,6 +127,6 @@ fn test_get_header_invalid_receipt_root() {
 fn test_get_header_invalid_hash() {
     let hash = alter_array(hash);
     let blockPartial = BlockHeaderPartial { stateRoot, transactionsRoot, receiptsRoot, number, hash, encoded_len, encoded };
-    OracleMock::mock("get_header").returns(blockPartial);
+    let _ = OracleMock::mock("get_header").returns(blockPartial);
     assert(get_header(0).stateRoot == stateRoot);
 }

--- a/circuit/src/main.nr
+++ b/circuit/src/main.nr
@@ -6,7 +6,11 @@ use dep::proof;
 use crate::get_account::{get_account, AccountWithProof};
 use crate::get_header::{get_header, BlockHeaderPartial};
 
-fn main(block_no: pub Field, address: pub [u8; 20], state_root: [u8; proof::KEY_LENGTH]) -> pub AccountWithProof {
+fn main(
+    block_no: pub Field,
+    address: pub [u8; 20],
+    state_root: [u8; proof::KEY_LENGTH]
+) -> pub AccountWithProof {
     let account = get_account(block_no, address, state_root);
     get_header(block_no);
     account


### PR DESCRIPTION
Before:
```sh
warning: alter_array is private and not visible from the current module
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:97:21
   │
97 │     let stateRoot = alter_array(stateRoot);
   │                     ----------- alter_array is private
   │

warning: alter_array is private and not visible from the current module
    ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:105:28
    │
105 │     let transactionsRoot = alter_array(transactionsRoot);
    │                            ----------- alter_array is private
    │

warning: alter_array is private and not visible from the current module
    ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:113:24
    │
113 │     let receiptsRoot = alter_array(receiptsRoot);
    │                        ----------- alter_array is private
    │

warning: alter_array is private and not visible from the current module
    ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:121:16
    │
121 │     let hash = alter_array(hash);
    │                ----------- alter_array is private
    │

warning: get_account is private and not visible from the current module
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/main.nr:10:19
   │
10 │     let account = get_account(block_no, address, state_root);
   │                   ----------- get_account is private
   │

warning: get_header is private and not visible from the current module
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/main.nr:11:5
   │
11 │     get_header(block_no);
   │     ---------- get_header is private
   │

warning: Unused expression result of type OracleMock
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:91:5
   │
91 │     OracleMock::mock("get_header").returns(blockPartial);
   │     ----------------------------------------------------
   │

warning: Unused expression result of type OracleMock
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:99:5
   │
99 │     OracleMock::mock("get_header").returns(blockPartial);
   │     ----------------------------------------------------
   │

warning: Unused expression result of type OracleMock
    ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:107:5
    │
107 │     OracleMock::mock("get_header").returns(blockPartial);
    │     ----------------------------------------------------
    │

warning: Unused expression result of type OracleMock
    ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:115:5
    │
115 │     OracleMock::mock("get_header").returns(blockPartial);
    │     ----------------------------------------------------
    │

warning: Unused expression result of type OracleMock
    ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/get_header.nr:123:5
    │
123 │     OracleMock::mock("get_header").returns(blockPartial);
    │     ----------------------------------------------------
    │

warning: Unused expression result of type BlockHeaderPartial
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/main.nr:11:5
   │
11 │     get_header(block_no);
   │     --------------------
   │
```

after:
```sh
warning: Unused expression result of type BlockHeaderPartial
   ┌─ /Users/leonidlogvinov/Dev/ZK/noir-ethereum-history-api/circuit/src/main.nr:15:5
   │
15 │     get_header(block_no);
   │     --------------------
   │

```