### PR TITLE
Split nargo verify and e2e tests into two different workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,12 @@
+# Workflows
+
+- [Circuits profiling](./circuits_profile.yml)
+  - Runs `nargo info` and stores the results into an artefact
+- [Circuits tests](./circuits_test.yml)
+  - Runs `nargo test`
+- [Circuits E2E tests](./circuits_e2e.yml)
+  - Runs `nargo prove` & `nargo verify`
+- [Solidity tests](./contract_test.yml)
+  - Runs `forge test`
+- [TypeScript E2E tests using solidity verifiers](./e2e_test.yml)
+  - Runs `yarn test:e2e`

--- a/.github/workflows/circuits_e2e.yaml
+++ b/.github/workflows/circuits_e2e.yaml
@@ -1,10 +1,10 @@
-name: E2E Tests
+name: Circuits E2E Tests
 
 on: [push]
 
 jobs:
   test:
-    name: E2E Tests
+    name: Circuits E2E Tests
     runs-on: 32-core-ubuntu-runner
     environment: CI
     env:
@@ -47,30 +47,10 @@ jobs:
           nargo prove --package get_header --oracle-resolver=http://localhost:5555
           nargo prove --package get_account --oracle-resolver=http://localhost:5555
 
-      - name: Run nargo codegen-verifier
+      - name: Veirfy Proof
         run: |
-          nargo codegen-verifier --package get_header
-          nargo codegen-verifier --package get_account
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
-      - name: Compile Smart Contract
-        working-directory: ethereum_history_api/contracts
-        run: forge build
-
-      - name: Run TypeScript Build
-        run: yarn build
-
-      - name: Run Unit Tests
-        working-directory: ethereum_history_api/oracles
-        run: yarn test:unit
-
-      - name: Run e2e Tests
-        working-directory: ethereum_history_api/tests
-        run: yarn test:e2e
+          nargo verify --package get_header
+          nargo verify --package get_account
 
       - name: Stop Oracle Server
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # noir-ethereum-history-api
 
-_noir-ethereum-history-api_ is a [Noir](https://noir-lang.org) library for proving and verifying account balances and smart contracts storage slots on the Ethereum blockchain and other EVMs. 
+_noir-ethereum-history-api_ is a [Noir](https://noir-lang.org) library for proving and verifying account balances and smart contracts storage slots on the Ethereum blockchain and other EVMs.
 
 As for now, it allows for proving and verifying last 256 blocks.
 
 It is currently in a development stage.
 
 ### Repository structure
+
 This monorepo consists of four sub-projects:
-* [Circuits](ethereum_history_api/circuits/lib/) - Noir circuits to generate account and storage proofs for historical blocks data
-* [Contracts](ethereum_history_api/contracts/) - related Solidity contracts with tests
-* [Oracles](ethereum_history_api/oracles/) - TypeScript oracle server that provides data for circuits
-* [Tests](ethereum_history_api/tests/) - e2e tests in TypeScript
+
+- [Circuits](ethereum_history_api/circuits/lib/) - Noir circuits to generate account and storage proofs for historical blocks data
+- [Contracts](ethereum_history_api/contracts/) - related Solidity contracts with tests
+- [Oracles](ethereum_history_api/oracles/) - TypeScript oracle server that provides data for circuits
+- [Tests](ethereum_history_api/tests/) - e2e tests in TypeScript
 
 ## Prerequisites
 
-_nargo_ and _foundry_ must be installed in order to compile and test code in this repository. 
+_nargo_ and _foundry_ must be installed in order to compile and test code in this repository.
 
-* [nargo installation](https://noir-lang.org/docs/getting_started/installation/)
-* [foundry installation](https://book.getfoundry.sh/getting-started/installation)
-* [yarn](https://yarnpkg.com) >= 4.1.0
-
+- [nargo installation](https://noir-lang.org/docs/getting_started/installation/)
+- [foundry installation](https://book.getfoundry.sh/getting-started/installation)
+- [yarn](https://yarnpkg.com) >= 4.1.0
 
 ## Getting started
 
@@ -31,6 +32,7 @@ Run `yarn` to install dependencies.
 ### Running checks
 
 To run all static checks (eslint, prettier, typecheck) type:
+
 ```sh
 yarn check
 ```
@@ -43,13 +45,15 @@ To run checks individually use:
 
 `yarn typecheck:all` - to run `typescript` checks on the whole repo
 
-
 ### Compilation & testing
 
 Compilation and testing instructions for individual projects:
-* [Circuits](ethereum_history_api/circuits/lib/README.md#compilation)
-* [Contracts](ethereum_history_api/contracts/README.md#build) 
-* [Oracles](ethereum_history_api/oracles/README.md)
-* [Tests](ethereum_history_api/tests/README.md)
 
+- [Circuits](ethereum_history_api/circuits/lib/README.md#compilation)
+- [Contracts](ethereum_history_api/contracts/README.md#build)
+- [Oracles](ethereum_history_api/oracles/README.md)
+- [Tests](ethereum_history_api/tests/README.md)
 
+### CI workflows
+
+We use Github actions to run tests on CI. For a detailed description of what does each workflow do consult [Workflow Docs](./.github/workflows/README.md)


### PR DESCRIPTION
Now the critical path on CI takes only 3 minutes
Also we now have a docs page that describes what each workflow does