### PR TITLE
Solidity storage layout functions

### DIFF
--- a/ethereum_history_api/circuits/lib/src/lib.nr
+++ b/ethereum_history_api/circuits/lib/src/lib.nr
@@ -6,5 +6,6 @@ mod header_test;
 mod header_int_test;
 mod misc;
 mod fixtures;
+mod solidity_storage_layout;
 
 global HASH_LENGTH = 32;

--- a/ethereum_history_api/circuits/lib/src/misc.nr
+++ b/ethereum_history_api/circuits/lib/src/misc.nr
@@ -1,3 +1,4 @@
 mod arrays;
 mod arrays_test;
 mod types;
+mod U256;

--- a/ethereum_history_api/circuits/lib/src/misc.nr
+++ b/ethereum_history_api/circuits/lib/src/misc.nr
@@ -2,3 +2,4 @@ mod arrays;
 mod arrays_test;
 mod types;
 mod U256;
+mod U256_test;

--- a/ethereum_history_api/circuits/lib/src/misc/U256.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/U256.nr
@@ -1,47 +1,23 @@
 use crate::misc::types::U256;
-use crate::misc::arrays::{array_equals, pad_left};
+use crate::misc::arrays::pad_left;
 use dep::std::wrapping_add;
 use dep::u2b::u64_to_u8;
 
 global MAX_U8: u8 = 255;
 
-fn is_overflow(left: u8, right: u8) -> bool {
+pub(crate) fn is_overflow(left: u8, right: u8) -> bool {
     // We want to check if `left + right > MAX_U8`
     // `left + right` can overflow, but `MAX_U8 - right` does not
     left > MAX_U8 - right
 }
 
-#[test]
-fn test_is_overflow() {
-    assert(is_overflow(255, 1));
-    assert(is_overflow(100, 200));
-    assert(is_overflow(255, 255));
-
-    assert(!is_overflow(255, 0));
-    assert(!is_overflow(0, 255));
-    assert(!is_overflow(100, 100));
-    assert(!is_overflow(0, 0));
-}
-
-fn overflowing_add(lhs: u8, rhs: u8) -> (u8, u1) {
+pub(crate) fn overflowing_add(lhs: u8, rhs: u8) -> (u8, u1) {
     let sum = wrapping_add(lhs, rhs);
     let carry = is_overflow(lhs, rhs) as u1;
     (sum, carry)
 }
 
-#[test]
-fn test_overflowing_add() {
-    assert(overflowing_add(255, 1) == (0, 1));
-    assert(overflowing_add(100, 200) == (44, 1));
-    assert(overflowing_add(255, 255) == (254, 1));
-
-    assert(overflowing_add(255, 0) == (255, 0));
-    assert(overflowing_add(0, 255) == (255, 0));
-    assert(overflowing_add(100, 100) == (200, 0));
-    assert(overflowing_add(0, 0) == (0, 0));
-}
-
-fn overflowing_add_with_previous_carry(left: u8, right: u8, carry: u1) -> (u8, u1) {
+pub(crate) fn overflowing_add_with_previous_carry(left: u8, right: u8, carry: u1) -> (u8, u1) {
     let (sum, carry1) = overflowing_add(left, right);
     let (sum, carry2) = overflowing_add(sum, carry as u8);
     // It's never the case that both `carry1` and `carry2` are 1
@@ -49,27 +25,6 @@ fn overflowing_add_with_previous_carry(left: u8, right: u8, carry: u1) -> (u8, u
     // the sum will be 511 which is less than 512
     let carry = carry1 | carry2;
     (sum, carry)
-}
-
-#[test]
-fn test_overflowing_add_with_previous_carry() {
-    assert(overflowing_add_with_previous_carry(255, 0, 0) == (255, 0));
-    assert(overflowing_add_with_previous_carry(0, 255, 0) == (255, 0));
-    assert(overflowing_add_with_previous_carry(100, 100, 0) == (200, 0));
-    assert(overflowing_add_with_previous_carry(0, 0, 0) == (0, 0));
-
-    assert(overflowing_add_with_previous_carry(255, 1, 0) == (0, 1));
-    assert(overflowing_add_with_previous_carry(100, 200, 0) == (44, 1));
-    assert(overflowing_add_with_previous_carry(255, 255, 0) == (254, 1));
-
-    assert(overflowing_add_with_previous_carry(255, 0, 1) == (0, 1));
-    assert(overflowing_add_with_previous_carry(0, 255, 1) == (0, 1));
-    assert(overflowing_add_with_previous_carry(100, 100, 1) == (201, 0));
-    assert(overflowing_add_with_previous_carry(0, 0, 1) == (1, 0));
-
-    assert(overflowing_add_with_previous_carry(255, 1, 1) == (1, 1));
-    assert(overflowing_add_with_previous_carry(100, 200, 1) == (45, 1));
-    assert(overflowing_add_with_previous_carry(255, 255, 1) == (255, 1));
 }
 
 pub(crate) fn add_u64_to_U256(left: U256, right: u64) -> U256 {
@@ -85,30 +40,4 @@ pub(crate) fn add_u64_to_U256(left: U256, right: u64) -> U256 {
     }
     assert(carry == 0, "Overflow");
     result
-}
-
-#[test]
-fn test_add_u64_to_U256() {
-    let one = pad_left([1]);
-    let two = 2;
-    let three = pad_left([3]);
-
-    assert(array_equals(add_u64_to_U256(one, two), three));
-}
-
-#[test]
-fn test_add_u64_to_U256_with_carry() {
-    let one = pad_left([255]);
-    let two = 2;
-    let three = pad_left([1, 1]);
-
-    assert(array_equals(add_u64_to_U256(one, two), three));
-}
-
-#[test(should_fail_with="Overflow")]
-fn test_add_u64_to_U256_overflows() {
-    let MAX_U256 = [255; 32];
-    let one = 1;
-
-    let _ = add_u64_to_U256(MAX_U256, one);
 }

--- a/ethereum_history_api/circuits/lib/src/misc/U256.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/U256.nr
@@ -1,0 +1,114 @@
+use crate::misc::types::U256;
+use crate::misc::arrays::{array_equals, pad_left};
+use dep::std::wrapping_add;
+use dep::u2b::u64_to_u8;
+
+global MAX_U8: u8 = 255;
+
+fn is_overflow(left: u8, right: u8) -> bool {
+    // We want to check if `left + right > MAX_U8`
+    // `left + right` can overflow, but `MAX_U8 - right` does not
+    left > MAX_U8 - right
+}
+
+#[test]
+fn test_is_overflow() {
+    assert(is_overflow(255, 1));
+    assert(is_overflow(100, 200));
+    assert(is_overflow(255, 255));
+
+    assert(!is_overflow(255, 0));
+    assert(!is_overflow(0, 255));
+    assert(!is_overflow(100, 100));
+    assert(!is_overflow(0, 0));
+}
+
+fn overflowing_add(lhs: u8, rhs: u8) -> (u8, u1) {
+    let sum = wrapping_add(lhs, rhs);
+    let carry = is_overflow(lhs, rhs) as u1;
+    (sum, carry)
+}
+
+#[test]
+fn test_overflowing_add() {
+    assert(overflowing_add(255, 1) == (0, 1));
+    assert(overflowing_add(100, 200) == (44, 1));
+    assert(overflowing_add(255, 255) == (254, 1));
+
+    assert(overflowing_add(255, 0) == (255, 0));
+    assert(overflowing_add(0, 255) == (255, 0));
+    assert(overflowing_add(100, 100) == (200, 0));
+    assert(overflowing_add(0, 0) == (0, 0));
+}
+
+fn overflowing_add_with_previous_carry(left: u8, right: u8, carry: u1) -> (u8, u1) {
+    let (sum, carry1) = overflowing_add(left, right);
+    let (sum, carry2) = overflowing_add(sum, carry as u8);
+    // It's never the case that both `carry1` and `carry2` are 1
+    // The maximum value of u8 is 255, so even if lhs is 255 and rhs is 255 and carry is 1,
+    // the sum will be 511 which is less than 512
+    let carry = carry1 | carry2;
+    (sum, carry)
+}
+
+#[test]
+fn test_overflowing_add_with_previous_carry() {
+    assert(overflowing_add_with_previous_carry(255, 0, 0) == (255, 0));
+    assert(overflowing_add_with_previous_carry(0, 255, 0) == (255, 0));
+    assert(overflowing_add_with_previous_carry(100, 100, 0) == (200, 0));
+    assert(overflowing_add_with_previous_carry(0, 0, 0) == (0, 0));
+
+    assert(overflowing_add_with_previous_carry(255, 1, 0) == (0, 1));
+    assert(overflowing_add_with_previous_carry(100, 200, 0) == (44, 1));
+    assert(overflowing_add_with_previous_carry(255, 255, 0) == (254, 1));
+
+    assert(overflowing_add_with_previous_carry(255, 0, 1) == (0, 1));
+    assert(overflowing_add_with_previous_carry(0, 255, 1) == (0, 1));
+    assert(overflowing_add_with_previous_carry(100, 100, 1) == (201, 0));
+    assert(overflowing_add_with_previous_carry(0, 0, 1) == (1, 0));
+
+    assert(overflowing_add_with_previous_carry(255, 1, 1) == (1, 1));
+    assert(overflowing_add_with_previous_carry(100, 200, 1) == (45, 1));
+    assert(overflowing_add_with_previous_carry(255, 255, 1) == (255, 1));
+}
+
+pub(crate) fn add_u64_to_U256(left: U256, right: u64) -> U256 {
+    let right: U256 = pad_left(u64_to_u8(right));
+    let mut result = [0; 32];
+    let mut carry = 0;
+    for i in 0..32 {
+        // This addtion is Big Endian because U256 is Big Endian in Solidity/EVM
+        let reverse_i = 31 - i;
+        let (sum, local_carry) = overflowing_add_with_previous_carry(left[reverse_i], right[reverse_i], carry);
+        result[reverse_i] = sum;
+        carry = local_carry;
+    }
+    assert(carry == 0, "Overflow");
+    result
+}
+
+#[test]
+fn test_add_u64_to_U256() {
+    let one = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    let two = 2;
+    let three = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3];
+
+    assert(array_equals(add_u64_to_U256(one, two), three));
+}
+
+#[test]
+fn test_add_u64_to_U256_with_carry() {
+    let one = pad_left([255]);
+    let two = 2;
+    let three = pad_left([1, 1]);
+
+    assert(array_equals(add_u64_to_U256(one, two), three));
+}
+
+#[test(should_fail_with="Overflow")]
+fn test_add_u64_to_U256_overflows() {
+    let MAX_U256 = [255; 32];
+    let one = 1;
+
+    let _ = add_u64_to_U256(MAX_U256, one);
+}

--- a/ethereum_history_api/circuits/lib/src/misc/U256.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/U256.nr
@@ -89,9 +89,9 @@ pub(crate) fn add_u64_to_U256(left: U256, right: u64) -> U256 {
 
 #[test]
 fn test_add_u64_to_U256() {
-    let one = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    let one = pad_left([1]);
     let two = 2;
-    let three = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3];
+    let three = pad_left([3]);
 
     assert(array_equals(add_u64_to_U256(one, two), three));
 }

--- a/ethereum_history_api/circuits/lib/src/misc/U256_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/U256_test.nr
@@ -1,0 +1,80 @@
+use crate::misc::{
+    U256::{
+        is_overflow,
+        overflowing_add,
+        overflowing_add_with_previous_carry,
+        add_u64_to_U256
+    },
+    arrays::{array_equals, pad_left}
+};
+
+#[test]
+fn test_is_overflow() {
+    assert(is_overflow(255, 1));
+    assert(is_overflow(100, 200));
+    assert(is_overflow(255, 255));
+
+    assert(!is_overflow(255, 0));
+    assert(!is_overflow(0, 255));
+    assert(!is_overflow(100, 100));
+    assert(!is_overflow(0, 0));
+}
+
+#[test]
+fn test_overflowing_add() {
+    assert(overflowing_add(255, 1) == (0, 1));
+    assert(overflowing_add(100, 200) == (44, 1));
+    assert(overflowing_add(255, 255) == (254, 1));
+
+    assert(overflowing_add(255, 0) == (255, 0));
+    assert(overflowing_add(0, 255) == (255, 0));
+    assert(overflowing_add(100, 100) == (200, 0));
+    assert(overflowing_add(0, 0) == (0, 0));
+}
+
+#[test]
+fn test_overflowing_add_with_previous_carry() {
+    assert(overflowing_add_with_previous_carry(255, 0, 0) == (255, 0));
+    assert(overflowing_add_with_previous_carry(0, 255, 0) == (255, 0));
+    assert(overflowing_add_with_previous_carry(100, 100, 0) == (200, 0));
+    assert(overflowing_add_with_previous_carry(0, 0, 0) == (0, 0));
+
+    assert(overflowing_add_with_previous_carry(255, 1, 0) == (0, 1));
+    assert(overflowing_add_with_previous_carry(100, 200, 0) == (44, 1));
+    assert(overflowing_add_with_previous_carry(255, 255, 0) == (254, 1));
+
+    assert(overflowing_add_with_previous_carry(255, 0, 1) == (0, 1));
+    assert(overflowing_add_with_previous_carry(0, 255, 1) == (0, 1));
+    assert(overflowing_add_with_previous_carry(100, 100, 1) == (201, 0));
+    assert(overflowing_add_with_previous_carry(0, 0, 1) == (1, 0));
+
+    assert(overflowing_add_with_previous_carry(255, 1, 1) == (1, 1));
+    assert(overflowing_add_with_previous_carry(100, 200, 1) == (45, 1));
+    assert(overflowing_add_with_previous_carry(255, 255, 1) == (255, 1));
+}
+
+#[test]
+fn test_add_u64_to_U256() {
+    let one = pad_left([1]);
+    let two = 2;
+    let three = pad_left([3]);
+
+    assert(array_equals(add_u64_to_U256(one, two), three));
+}
+
+#[test]
+fn test_add_u64_to_U256_with_carry() {
+    let one = pad_left([255]);
+    let two = 2;
+    let three = pad_left([1, 1]);
+
+    assert(array_equals(add_u64_to_U256(one, two), three));
+}
+
+#[test(should_fail_with="Overflow")]
+fn test_add_u64_to_U256_overflows() {
+    let MAX_U256 = [255; 32];
+    let one = 1;
+
+    let _ = add_u64_to_U256(MAX_U256, one);
+}

--- a/ethereum_history_api/circuits/lib/src/misc/arrays.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays.nr
@@ -30,3 +30,11 @@ pub fn sub_array_equals<T, N, M>(subarray: [T; N], array: [T; M], offset: Field)
 pub fn array_equals<T, N>(array1: [T; N], array2: [T; N]) -> bool where T: Eq {
     sub_array_equals(array1, array2, 0)
 }
+
+pub fn pad_left<LEN, PADDED_LEN>(array: [u8; LEN]) -> [u8; PADDED_LEN] {
+    let mut result = [0; PADDED_LEN];
+    for i in 0..LEN {
+        result[PADDED_LEN - LEN + i] = array[i];
+    }
+    result
+}

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -1,4 +1,4 @@
-use crate::misc::arrays::{sub_array_equals_up_to_length, sub_array_equals, array_equals};
+use crate::misc::arrays::{sub_array_equals_up_to_length, sub_array_equals, array_equals, pad_left};
 
 #[test]
 fn test_assert_sub_array_equals() {
@@ -69,4 +69,11 @@ fn test_array_not_equals() {
     let array: [Field; 3] = [1, 2, 3];
     let other_array: [Field; 3] = [1, 2, 4];
     assert(array_equals(array, other_array), "Arrays not equal");
+}
+
+#[test]
+fn test_pad_left() {
+    let array: [u8; 2] = [1, 2];
+    let padded_array: [u8; 4] = [0, 0, 1, 2];
+    assert(array_equals(padded_array, pad_left(array)));
 }

--- a/ethereum_history_api/circuits/lib/src/misc/types.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/types.nr
@@ -1,2 +1,3 @@
 type Address = [u8; 20];
 type Bytes32 = [u8; 32];
+type U256 = Bytes32;

--- a/ethereum_history_api/circuits/lib/src/solidity_storage_layout.nr
+++ b/ethereum_history_api/circuits/lib/src/solidity_storage_layout.nr
@@ -1,0 +1,51 @@
+use crate::misc::{
+    types::U256,
+    U256::add_u64_to_U256,
+    arrays::pad_left
+};
+use dep::std::hash::keccak256;
+
+fn map(slot: U256, key: U256) -> U256 {
+    let mut preimage: [u8; 64] = [0; 64];
+    for i in 0..32 {
+        preimage[i] = key[i];
+    }
+    for i in 0..32 {
+        preimage[i + 32] = slot[i];
+    }
+    let storage_slot = keccak256(preimage, 64);
+    storage_slot
+}
+
+fn array(slot: U256, index: u64) -> U256 {
+    let mut array_storage_slot = keccak256(slot, 32);
+    let array_element_storage_slot = add_u64_to_U256(array_storage_slot, index);
+    array_element_storage_slot
+}
+
+#[test]
+fn test_map() {
+    let usdc_balance_slot = pad_left([9]);
+    // 0x55fe002aeff02f77364de339a1292923a15844b8
+    let circle_address = pad_left([85, 254, 0, 42, 239, 240, 47, 119, 54, 77, 227, 57, 161, 41, 41, 35, 161, 88, 68, 184]);
+    // 0x57d18af793d7300c4ba46d192ec7aa095070dde6c52c687c6d0d92fb8532b305
+    let usdc_circle_storage_slot = [
+        87, 209, 138, 247, 147, 215, 48, 12, 75, 164, 109, 25, 46, 199, 170, 9, 80, 112, 221, 230, 197, 44, 104, 124, 109, 13, 146, 251, 133, 50, 179, 5
+    ];
+
+    // https://evm.storage/eth/19333810/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/balanceAndBlacklistStates.0x55fe002aeff02f77364de339a1292923a15844b8#table
+    assert_eq(map(usdc_balance_slot, circle_address), usdc_circle_storage_slot);
+}
+
+#[test]
+fn test_array() {
+    let mcd_cure_srcs_slot = pad_left([2]);
+    let index = 1;
+    // 0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5acf
+    let mcd_cure_srcs_first_element_storage_slot = [
+        64, 87, 135, 250, 18, 168, 35, 224, 242, 183, 99, 28, 196, 27, 59, 168, 130, 139, 51, 33, 202, 129, 17, 17, 250, 117, 205, 58, 163, 187, 90, 207
+    ];
+
+    // https://evm.storage/eth/19333810/0x0085c9feab2335447e1f4dc9bf3593a8e28bdfc7/srcs.1#map
+    assert_eq(array(mcd_cure_srcs_slot, index), mcd_cure_srcs_first_element_storage_slot);
+}

--- a/ethereum_history_api/circuits/lib/src/solidity_storage_layout.nr
+++ b/ethereum_history_api/circuits/lib/src/solidity_storage_layout.nr
@@ -1,26 +1,44 @@
 use crate::misc::{
-    types::U256,
+    types::{U256, Bytes32},
     U256::add_u64_to_U256,
     arrays::pad_left
 };
 use dep::std::hash::keccak256;
 
-fn map(slot: U256, key: U256) -> U256 {
-    let mut preimage: [u8; 64] = [0; 64];
+fn concat_Bytes32_values(left: Bytes32, right: Bytes32) -> [u8; 64] {
+    let mut result = [0; 64];
     for i in 0..32 {
-        preimage[i] = key[i];
+        result[i] = left[i];
     }
     for i in 0..32 {
-        preimage[i + 32] = slot[i];
+        result[32 + i] = right[i];
     }
+    result
+}
+
+pub fn map(slot: U256, key: U256) -> U256 {
+    let preimage = concat_Bytes32_values(key, slot);
     let storage_slot = keccak256(preimage, 64);
     storage_slot
 }
 
-fn array(slot: U256, index: u64) -> U256 {
+pub fn array(slot: U256, index: u64) -> U256 {
     let mut array_storage_slot = keccak256(slot, 32);
     let array_element_storage_slot = add_u64_to_U256(array_storage_slot, index);
     array_element_storage_slot
+}
+
+#[test]
+fn test_concat_Bytes32_values() {
+    let left = pad_left([1]);
+    let right = pad_left([2]);
+    let result = concat_Bytes32_values(left, right);
+    assert_eq(
+        result, [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2
+    ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds two public functions. `map` and `array`. They are used to compute solidity storage locations.
Later they would live in noir client library. This is just a preparation so that we have them.

Because of how arrays work - I needed to write some helper functions which are also included here