### PR TITLE
Syntax highlighting for Noir files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.yarn/releases/*    binary
 /.yarn/plugins/**/*  binary
 /.pnp.*              binary linguist-generated
+*.nr                 linguist-language=rust


### PR DESCRIPTION
Enable syntax highlighting for Noir files in github
Before:
<img width="471" alt="image" src="https://github.com/vlayer-xyz/noir-ethereum-history-api/assets/2027578/38938afb-9b46-446f-839a-32c37374629e">

After:
<img width="468" alt="image" src="https://github.com/vlayer-xyz/noir-ethereum-history-api/assets/2027578/669d6fc1-0263-4193-96e8-21b50ec5de6a">

