### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Leon Logvinon is an owner of the whole codebase except for Circuits and Contracts projects.
+*                               @LogvinovLeon
+/ethereum_history_api/circuits  @marekkirejczyk
+/ethereum_history_api/contracts @marekkirejczyk
+
+# Marek Kirejczyk is an owner of this CODEOWNERS file so that he is required to approve any changes in code ownership.
+/.github/CODEOWNERS             @marekkirejczyk


### PR DESCRIPTION
Added the CODEOWNERS file. 

Set @LogvinovLeon as an owner of the whole repo except for Circuits and Contracts project that are owned by @marekkirejczyk.

Set @marekkirejczyk as an owner of the CODEOWNERS file so that he is required to approve any changes in code ownership.