### PR TITLE
Add max node proof length assertion

### DIFF
--- a/ethereum_history_api/circuits/get_receipt/src/main.nr
+++ b/ethereum_history_api/circuits/get_receipt/src/main.nr
@@ -13,7 +13,7 @@ global MAX_LOG_DATA_SIZE = 128; // 4 * 32 (Eth word length)
 // MAX_BRANCH_LENGTH = 3 + 16 * 32 + 1 = 515
 global MAX_RECEIPT_TRIE_NODE_LENGTH = 515;
 global MAX_RECEIPT_PROOF_LENGTH = 3090; // MAX_RECEIPT_TRIE_NODE_LENGTH * MAX_RECEIPT_TREE_DEPTH
-global MAX_RECEIPT_RLP_LENGTH = 512; // TODO: Put the real value here
+global MAX_RECEIPT_RLP_LENGTH = 515; // TODO: Put the real value here
 
 fn main(
     block_number: pub Field,

--- a/ethereum_history_api/circuits/get_receipt/src/main.nr
+++ b/ethereum_history_api/circuits/get_receipt/src/main.nr
@@ -13,7 +13,8 @@ global MAX_LOG_DATA_SIZE = 128; // 4 * 32 (Eth word length)
 // MAX_BRANCH_LENGTH = 3 + 16 * 32 + 1 = 515
 global MAX_RECEIPT_TRIE_NODE_LENGTH = 515;
 global MAX_RECEIPT_PROOF_LENGTH = 3090; // MAX_RECEIPT_TRIE_NODE_LENGTH * MAX_RECEIPT_TREE_DEPTH
-global MAX_RECEIPT_RLP_LENGTH = 515; // TODO: Put the real value here
+// TODO: Handle the case where receipt is longer than the branch node
+global MAX_RECEIPT_RLP_LENGTH = 515; // == MAX_RECEIPT_TRIE_NODE_LENGTH 
 
 fn main(
     block_number: pub Field,

--- a/ethereum_history_api/oracles/src/noir/oracles/common/encode.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/common/encode.ts
@@ -52,6 +52,11 @@ export function encodeHex(hexString: string): Hex[] {
 }
 
 export function encodeProofNode(node: Hex): Hex[] {
+  const encodedNode = encodeHex(node);
+  assert(
+    encodedNode.length <= PROOF_ONE_LEVEL_LENGTH,
+    `Proof node length: ${encodedNode.length} is too large. Max proof node length: ${PROOF_ONE_LEVEL_LENGTH}`
+  );
   return padArray(encodeHex(node), PROOF_ONE_LEVEL_LENGTH, ZERO_PAD_VALUE);
 }
 


### PR DESCRIPTION
1. Added an assertion for max proof node length (it can't be larger than PROOF_ONE_LEVEL_LENGTH)
2. Fixed MAX_RECEIPT_RLP_LENGTH in getReceipt/src/main.nr to be the same as in accountOracle/encode.ts