### PR TITLE
Use package name from env variables falling back to uuid while creating a temp folder

### DIFF
--- a/ethereum_history_api/oracles/src/util/file.ts
+++ b/ethereum_history_api/oracles/src/util/file.ts
@@ -2,8 +2,8 @@ import { parse, stringify } from './json-bigint.js';
 import fs, { writeFile } from 'fs/promises';
 import os from 'os';
 import prettier from 'prettier';
+import { randomUUID } from 'crypto';
 import path from 'path';
-import packgeJson from '../../package.json';
 import { BaseFixture } from '../fixtures/types.js';
 import { TransactionReceipt } from '../types.js';
 
@@ -28,7 +28,8 @@ export async function readObject<TFixture extends BaseFixture<TResult>, TResult 
 }
 
 export async function withTempFile<T>(callback: (path: string) => Promise<T>): Promise<T> {
-  const testTempDir = await fs.mkdtemp(`${os.tmpdir()}/${packgeJson.name}-temp-dir-`);
+  const pkgName = process.env.npm_package_name ?? randomUUID();
+  const testTempDir = await fs.mkdtemp(`${os.tmpdir()}/${pkgName}-temp-dir`);
   const tempFilePath = `${testTempDir}/temp-${Date.now()}.json`;
   try {
     return await callback(tempFilePath);

--- a/ethereum_history_api/oracles/tsconfig.json
+++ b/ethereum_history_api/oracles/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.common.json",
-  "include": ["src/**/*", "src/noir/oracles/accountOracle/fixtures/*.json", "package.json"],
+  "include": ["src/**/*", "src/noir/oracles/accountOracle/fixtures/*.json"],
   "compilerOptions": {
     "rootDirs": ["src"],
     "outDir": "dist"


### PR DESCRIPTION
This issue was caused by us importing the package name from `package.json`. In theory - it should work, but I wasn't able to get to the root cause of the warning in reasonable time, so I've decided to remove this import and replace it.

We now get the package name from env variable set by npm/yarn. This will work locally. If we ever deploy this to the environment where this variable would be not set - we fallback to uuid.

It's only important that this folder name is human-readable locally for debugging tests.