### PR TITLE
Transpose RLP_List structure & renames

### DIFF
--- a/ethereum_history_api/circuits/lib/src/rlp/decode.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/decode.nr
@@ -25,9 +25,9 @@ struct RlpFragment {
     data_type: u64 // STRING or LIST
 }
 
-impl RlpFragment {
-    pub fn new(offset: u64, length: u64, data_type: u64) -> Self {
-        RlpFragment { offset, length, data_type }
+impl Default for RlpFragment {
+    fn default() -> Self {
+        RlpFragment { offset: 0, length: 0, data_type: 0 }
     }
 }
 
@@ -133,7 +133,7 @@ pub fn decode_string<N>(input: [u8; N]) -> (u64, u64) {
 ///   of a list element points to the RLP header of that element.
 pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RlpList<NUM_FIELDS> {
     let mut num_fields: u64 = 0;
-    let mut fragments = [RlpFragment::new(0, 0, 0); NUM_FIELDS];
+    let mut fragments = [RlpFragment::default(); NUM_FIELDS];
 
     let mut RlpHeader {offset, length: payload_len, data_type: input_type} = decode_len(input);
 
@@ -169,7 +169,7 @@ pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RlpList<NUM_FIELDS> {
 /// Returns an RLP list look-up table.
 pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RlpList<NUM_FIELDS> {
     let mut num_fields: u64 = 0;
-    let mut fragments = [RlpFragment::new(0, 0, 0); NUM_FIELDS];
+    let mut fragments = [RlpFragment::default(); NUM_FIELDS];
 
     let mut RlpHeader {offset, length: payload_len, data_type: input_type} = decode_len(input);
     let total_len = payload_len + offset;

--- a/ethereum_history_api/circuits/lib/src/rlp/decode.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/decode.nr
@@ -20,22 +20,27 @@ impl RLP_Header {
     }
 }
 
-struct RLP_List<NUM_FIELDS> {
-    offset: [u64; NUM_FIELDS],
-    length: [u64; NUM_FIELDS],
+struct RLP_Fragment {
+    offset: u64,
+    length: u64,
     /// STRING or LIST
-    data_type: [u64; NUM_FIELDS],
+    data_type: u64
+}
+
+impl RLP_Fragment {
+    pub fn new(offset: u64, length: u64, data_type: u64) -> Self {
+        RLP_Fragment { offset, length, data_type }
+    }
+}
+
+struct RLP_List<NUM_FIELDS> {
+    rlp_fragments: [RLP_Fragment; NUM_FIELDS],
     num_fields: u64
 }
 
 impl<NUM_FIELDS> RLP_List<NUM_FIELDS> {
-    pub fn new(
-        offset: [u64; NUM_FIELDS],
-        length: [u64; NUM_FIELDS],
-        data_type: [u64; NUM_FIELDS],
-        num_fields: u64
-    ) -> Self {
-        RLP_List { offset, length, data_type, num_fields }
+    pub fn new(rlp_fragments: [RLP_Fragment; NUM_FIELDS], num_fields: u64) -> Self {
+        RLP_List { rlp_fragments, num_fields }
     }
 }
 
@@ -130,9 +135,7 @@ pub fn decode_string<N>(input: [u8; N]) -> (u64, u64) {
 ///   of a list element points to the RLP header of that element.
 pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
     let mut num_fields: u64 = 0;
-    let mut dec_off = [0; NUM_FIELDS];
-    let mut dec_len = [0; NUM_FIELDS];
-    let mut dec_type = [0; NUM_FIELDS];
+    let mut fragments = [RLP_Fragment::new(0, 0, 0); NUM_FIELDS];
 
     let mut RLP_Header {offset, length: payload_len, data_type: input_type} = decode_len(input);
 
@@ -151,9 +154,9 @@ pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
         let total_field_len = field_off + field_len;
 
         // Assign decoded data and set them to 0 if loop indicator false (Convenient for testing; could remove this later)
-        dec_off[i] = loop_ind * (offset + (1 - field_type) * field_off); // If the ith slot contains a list, include its RLP header.
-        dec_len[i] = loop_ind * (field_len + field_type * field_off); // If the ith slot contains a list, make sure to include the length of its header in the decoded data.
-        dec_type[i] = loop_ind * (field_type);
+        fragments[i].offset = loop_ind * (offset + (1 - field_type) * field_off); // If the ith slot contains a list, include its RLP header.
+        fragments[i].length = loop_ind * (field_len + field_type * field_off); // If the ith slot contains a list, make sure to include the length of its header in the decoded data.
+        fragments[i].data_type = loop_ind * (field_type);
 
         offset += loop_ind * total_field_len;
         num_fields += loop_ind;
@@ -161,16 +164,14 @@ pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
 
     assert(total_len == offset);
 
-    RLP_List::new(dec_off, dec_len, dec_type, num_fields)
+    RLP_List::new(fragments, num_fields)
 }
 
 /// RLP list decoder for lists of strings of length < 56 bytes.
 /// Returns an RLP list look-up table.
 pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
     let mut num_fields: u64 = 0;
-    let mut dec_off = [0; NUM_FIELDS];
-    let mut dec_len = [0; NUM_FIELDS];
-    let mut dec_type = [0; NUM_FIELDS];
+    let mut fragments = [RLP_Fragment::new(0, 0, 0); NUM_FIELDS];
 
     let mut RLP_Header {offset, length: payload_len, data_type: input_type} = decode_len(input);
     let total_len = payload_len + offset;
@@ -197,9 +198,9 @@ pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<N
 
         let total_field_len = field_off + field_len;
 
-        dec_off[i] = loop_ind * (offset + field_off);
-        dec_len[i] = loop_ind * (field_len);
-        dec_type[i] = loop_ind * (field_type);
+        fragments[i].offset = loop_ind * (offset + field_off);
+        fragments[i].length = loop_ind * (field_len);
+        fragments[i].data_type= loop_ind * (field_type);
 
         offset += loop_ind * total_field_len;
         num_fields += loop_ind;
@@ -207,7 +208,7 @@ pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<N
 
     assert(total_len == offset);
 
-    RLP_List::new(dec_off, dec_len, dec_type, num_fields)
+    RLP_List::new(fragments, num_fields)
 }
 
 pub fn copy_subarray<T, N, M>(arr: [T; N], offset: u64) -> [T; M] {
@@ -239,9 +240,14 @@ fn rlp_decode_test() {
     let output: RLP_List<5> = decode_list(input);
 
     assert(output.num_fields == 3);
-    assert(output.offset == [2, 6, 9, 0, 0]);
-    assert(output.length == [3, 3, 1, 0, 0]);
-    assert(output.data_type == [STRING; 5]);
+    let expected_offsets = [2, 6, 9, 0, 0];
+    let expected_lengths = [3, 3, 1, 0, 0];
+    let expected_data_types = [STRING; 5];
+    for i in 0..5 {
+        assert(output.rlp_fragments[i].offset == expected_offsets[i]);
+        assert(output.rlp_fragments[i].length == expected_lengths[i]);
+        assert(output.rlp_fragments[i].data_type == expected_data_types[i]);
+    }
 
     // Decode a list of 17 elements
     let input1 = [
@@ -251,12 +257,14 @@ fn rlp_decode_test() {
     let output1: RLP_List<17> = decode_list(input1);
 
     assert(output1.num_fields == 17);
-    assert(
-        output1.offset
-        == [4, 37, 70, 103, 136, 169, 202, 235, 268, 301, 334, 367, 400, 433, 466, 499, 532]
-    );
-    assert(output1.length == [32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0]);
-    assert(output1.data_type == [STRING; 17]);
+    let expected_offsets1 = [4, 37, 70, 103, 136, 169, 202, 235, 268, 301, 334, 367, 400, 433, 466, 499, 532];
+    let expected_lengths1 = [32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0];
+    let expected_data_types1 = [STRING; 17];
+    for i in 0..17 {
+        assert(output1.rlp_fragments[i].offset == expected_offsets1[i]);
+        assert(output1.rlp_fragments[i].length == expected_lengths1[i]);
+        assert(output1.rlp_fragments[i].data_type == expected_data_types1[i]);
+    }
 }
 
 // Test data length decoding on the RLP header of a >55-byte list

--- a/ethereum_history_api/circuits/lib/src/rlp/decode.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/decode.nr
@@ -7,40 +7,38 @@ global MAX_LEN_IN_BYTES: u64 = 2;
 global STRING: u64 = 0;
 global LIST: u64 = 1;
 
-struct RLP_Header {
+struct RlpHeader {
     offset: u64,
-    length: u64,
-    /// STRING or LIST
-    data_type: u64 
+    length: u64, 
+    data_type: u64 // STRING or LIST    
 }
 
-impl RLP_Header {
+impl RlpHeader {
     pub fn new(offset: u64, length: u64, data_type: u64) -> Self {
-        RLP_Header { offset, length, data_type }
+        RlpHeader { offset, length, data_type }
     }
 }
 
-struct RLP_Fragment {
+struct RlpFragment {
     offset: u64,
-    length: u64,
-    /// STRING or LIST
-    data_type: u64
+    length: u64,    
+    data_type: u64 // STRING or LIST
 }
 
-impl RLP_Fragment {
+impl RlpFragment {
     pub fn new(offset: u64, length: u64, data_type: u64) -> Self {
-        RLP_Fragment { offset, length, data_type }
+        RlpFragment { offset, length, data_type }
     }
 }
 
-struct RLP_List<NUM_FIELDS> {
-    rlp_fragments: [RLP_Fragment; NUM_FIELDS],
+struct RlpList<NUM_FIELDS> {
+    fragments: [RlpFragment; NUM_FIELDS],
     num_fields: u64
 }
 
-impl<NUM_FIELDS> RLP_List<NUM_FIELDS> {
-    pub fn new(rlp_fragments: [RLP_Fragment; NUM_FIELDS], num_fields: u64) -> Self {
-        RLP_List { rlp_fragments, num_fields }
+impl<NUM_FIELDS> RlpList<NUM_FIELDS> {
+    pub fn new(fragments: [RlpFragment; NUM_FIELDS], num_fields: u64) -> Self {
+        RlpList { fragments, num_fields }
     }
 }
 
@@ -67,7 +65,7 @@ pub fn data_len<N>(arr: [u8; N], lenlen: u64) -> u64 {
     out
 }
 
-pub fn decode_len<N>(arr: [u8; N]) -> RLP_Header {
+pub fn decode_len<N>(arr: [u8; N]) -> RlpHeader {
     let prefix = arr[0];
 
     // Prefix range indicators
@@ -112,12 +110,12 @@ pub fn decode_len<N>(arr: [u8; N]) -> RLP_Header {
 
     let data_type = (prefix >= 0xc0) as u64;
 
-    RLP_Header::new(offset, len, data_type)
+    RlpHeader::new(offset, len, data_type)
 }
 
 /// RLP string decoder. Returns offset and length of RLP-encoded string as a tuple.
 pub fn decode_string<N>(input: [u8; N]) -> (u64, u64) {
-    let mut RLP_Header {offset, length, data_type} = decode_len(input);
+    let mut RlpHeader {offset, length, data_type} = decode_len(input);
 
     let total_len = length + offset;
 
@@ -133,11 +131,11 @@ pub fn decode_string<N>(input: [u8; N]) -> (u64, u64) {
 /// # Quirks
 /// * For string elements, the offset points to the payload, whereas the offset
 ///   of a list element points to the RLP header of that element.
-pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
+pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RlpList<NUM_FIELDS> {
     let mut num_fields: u64 = 0;
-    let mut fragments = [RLP_Fragment::new(0, 0, 0); NUM_FIELDS];
+    let mut fragments = [RlpFragment::new(0, 0, 0); NUM_FIELDS];
 
-    let mut RLP_Header {offset, length: payload_len, data_type: input_type} = decode_len(input);
+    let mut RlpHeader {offset, length: payload_len, data_type: input_type} = decode_len(input);
 
     let total_len = payload_len + offset;
 
@@ -150,7 +148,7 @@ pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
 
         // Make sure the index doesn't overshoot
         let header: [u8; MAX_LEN_IN_BYTES + 1] = copy_subarray(input, offset);
-        let RLP_Header {offset: field_off, length: field_len, data_type: field_type} = decode_len(header);
+        let RlpHeader {offset: field_off, length: field_len, data_type: field_type} = decode_len(header);
         let total_field_len = field_off + field_len;
 
         // Assign decoded data and set them to 0 if loop indicator false (Convenient for testing; could remove this later)
@@ -164,16 +162,16 @@ pub fn decode_list<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
 
     assert(total_len == offset);
 
-    RLP_List::new(fragments, num_fields)
+    RlpList::new(fragments, num_fields)
 }
 
 /// RLP list decoder for lists of strings of length < 56 bytes.
 /// Returns an RLP list look-up table.
-pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
+pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RlpList<NUM_FIELDS> {
     let mut num_fields: u64 = 0;
-    let mut fragments = [RLP_Fragment::new(0, 0, 0); NUM_FIELDS];
+    let mut fragments = [RlpFragment::new(0, 0, 0); NUM_FIELDS];
 
-    let mut RLP_Header {offset, length: payload_len, data_type: input_type} = decode_len(input);
+    let mut RlpHeader {offset, length: payload_len, data_type: input_type} = decode_len(input);
     let total_len = payload_len + offset;
 
     assert(input_type == LIST);
@@ -208,7 +206,7 @@ pub fn decode_list_of_small_strings<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<N
 
     assert(total_len == offset);
 
-    RLP_List::new(fragments, num_fields)
+    RlpList::new(fragments, num_fields)
 }
 
 pub fn copy_subarray<T, N, M>(arr: [T; N], offset: u64) -> [T; M] {
@@ -231,22 +229,22 @@ fn strict_if(pred: bool, x: u64, y: u64) -> u64 {
 #[test]
 fn rlp_decode_test() {
     // Decode empty list
-    let empty_list: RLP_List<1> = decode_list([0xc0]);
+    let empty_list: RlpList<1> = decode_list([0xc0]);
 
     assert(empty_list.num_fields == 0);
 
     // Decode a list of 3 elements
     let input = [0xc9, 0x83, 0x63, 0x61, 0x74, 0x83, 0x64, 0x6f, 0x68, 0, 0];
-    let output: RLP_List<5> = decode_list(input);
+    let output: RlpList<5> = decode_list(input);
 
     assert(output.num_fields == 3);
     let expected_offsets = [2, 6, 9, 0, 0];
     let expected_lengths = [3, 3, 1, 0, 0];
     let expected_data_types = [STRING; 5];
     for i in 0..5 {
-        assert(output.rlp_fragments[i].offset == expected_offsets[i]);
-        assert(output.rlp_fragments[i].length == expected_lengths[i]);
-        assert(output.rlp_fragments[i].data_type == expected_data_types[i]);
+        assert(output.fragments[i].offset == expected_offsets[i]);
+        assert(output.fragments[i].length == expected_lengths[i]);
+        assert(output.fragments[i].data_type == expected_data_types[i]);
     }
 
     // Decode a list of 17 elements
@@ -254,35 +252,35 @@ fn rlp_decode_test() {
         249, 2, 17, 160, 10, 210, 58, 71, 229, 91, 254, 185, 245, 139, 35, 127, 191, 50, 125, 165, 19, 165, 59, 86, 127, 77, 226, 197, 94, 143, 9, 69, 104, 149, 113, 39, 160, 164, 115, 165, 166, 228, 180, 44, 203, 222, 52, 48, 157, 214, 190, 69, 130, 116, 84, 133, 170, 215, 193, 212, 152, 106, 149, 100, 253, 145, 220, 246, 94, 160, 69, 11, 1, 238, 164, 195, 225, 91, 51, 198, 134, 50, 21, 34, 253, 120, 157, 26, 173, 81, 148, 24, 94, 179, 165, 5, 99, 85, 90, 78, 104, 180, 160, 82, 128, 145, 254, 48, 73, 106, 165, 234, 223, 46, 5, 168, 79, 141, 218, 64, 98, 200, 87, 199, 28, 213, 222, 164, 182, 145, 219, 253, 186, 121, 39, 160, 167, 139, 46, 219, 193, 195, 174, 240, 47, 40, 188, 121, 97, 50, 227, 220, 35, 99, 122, 36, 94, 78, 156, 78, 197, 54, 232, 163, 249, 213, 16, 58, 160, 111, 180, 73, 26, 200, 238, 6, 49, 66, 159, 230, 23, 226, 13, 10, 230, 7, 51, 103, 45, 139, 187, 57, 125, 86, 1, 146, 77, 200, 196, 223, 158, 160, 55, 41, 196, 37, 89, 112, 4, 6, 183, 246, 239, 121, 175, 146, 171, 71, 19, 99, 239, 56, 75, 116, 235, 20, 239, 208, 243, 25, 211, 222, 248, 120, 160, 203, 87, 65, 73, 168, 197, 46, 86, 209, 173, 204, 46, 232, 157, 204, 145, 75, 151, 105, 166, 72, 142, 173, 255, 186, 120, 43, 121, 104, 228, 130, 134, 160, 150, 115, 130, 186, 247, 99, 108, 21, 244, 243, 60, 208, 96, 34, 93, 32, 175, 77, 181, 18, 59, 49, 192, 153, 255, 123, 231, 108, 251, 75, 134, 92, 160, 78, 107, 27, 31, 43, 92, 213, 101, 63, 87, 83, 248, 163, 19, 104, 103, 84, 248, 119, 180, 32, 209, 82, 52, 250, 148, 101, 219, 76, 194, 160, 125, 160, 83, 37, 183, 243, 189, 9, 79, 122, 28, 120, 150, 139, 190, 225, 222, 184, 206, 225, 117, 233, 244, 162, 244, 212, 38, 220, 37, 129, 215, 25, 93, 53, 160, 229, 6, 255, 207, 78, 120, 107, 238, 212, 128, 106, 189, 84, 39, 136, 172, 149, 67, 89, 238, 163, 122, 88, 90, 149, 80, 59, 121, 249, 7, 238, 1, 160, 81, 214, 156, 64, 149, 165, 65, 36, 216, 223, 167, 73, 213, 180, 230, 230, 32, 106, 193, 147, 176, 40, 93, 119, 210, 13, 1, 159, 16, 112, 114, 103, 160, 211, 15, 4, 49, 74, 86, 24, 146, 109, 246, 80, 207, 194, 97, 226, 153, 241, 94, 43, 233, 192, 2, 152, 171, 150, 86, 26, 250, 234, 179, 74, 156, 160, 175, 157, 156, 73, 109, 26, 48, 12, 182, 175, 211, 173, 181, 241, 131, 247, 105, 98, 255, 101, 7, 227, 21, 63, 78, 41, 155, 58, 231, 222, 15, 141, 160, 219, 213, 163, 116, 191, 119, 232, 215, 182, 77, 130, 102, 90, 48, 66, 197, 228, 202, 43, 169, 232, 246, 11, 23, 100, 50, 211, 205, 202, 115, 60, 49, 128
     ];
 
-    let output1: RLP_List<17> = decode_list(input1);
+    let output1: RlpList<17> = decode_list(input1);
 
     assert(output1.num_fields == 17);
     let expected_offsets1 = [4, 37, 70, 103, 136, 169, 202, 235, 268, 301, 334, 367, 400, 433, 466, 499, 532];
     let expected_lengths1 = [32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0];
     let expected_data_types1 = [STRING; 17];
     for i in 0..17 {
-        assert(output1.rlp_fragments[i].offset == expected_offsets1[i]);
-        assert(output1.rlp_fragments[i].length == expected_lengths1[i]);
-        assert(output1.rlp_fragments[i].data_type == expected_data_types1[i]);
+        assert(output1.fragments[i].offset == expected_offsets1[i]);
+        assert(output1.fragments[i].length == expected_lengths1[i]);
+        assert(output1.fragments[i].data_type == expected_data_types1[i]);
     }
 }
 
 // Test data length decoding on the RLP header of a >55-byte list
 #[test]
 fn data_len_test_unpadded() {
-    let rlp_header = [249, 1, 109];
-    let lenlen = (rlp_header[0] - 0xf7) as u64;
-    assert(data_len(rlp_header, lenlen) == 0x016d);
+    let RlpHeader = [249, 1, 109];
+    let lenlen = (RlpHeader[0] - 0xf7) as u64;
+    assert(data_len(RlpHeader, lenlen) == 0x016d);
 }
 
 // Test data length decoding on an RLP encoded >55-byte list with additional padding
 #[test]
 fn data_len_test_padded() {
-    let rlp_header = [
+    let RlpHeader = [
         249, 1, 109, 32, 185, 1, 105, 2, 249, 1, 101, 1, 132, 1, 3, 187, 10, 185, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 248, 90, 248, 88, 148, 56, 140, 129, 140, 168, 185, 37, 27, 57, 49, 49, 192, 138, 115, 106, 103, 204, 177, 146, 151, 225, 160, 39, 241, 42, 191, 227, 88, 96, 169, 169, 39, 180, 101, 187, 61, 74, 156, 35, 200, 66, 129, 116, 184, 63, 39, 143, 228, 94, 215, 180, 218, 38, 98, 160, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 36, 230, 50, 131, 46, 62, 226, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     ];
-    let lenlen = (rlp_header[0] - 0xf7) as u64;
-    assert(data_len(rlp_header, lenlen) == 0x016d);
+    let lenlen = (RlpHeader[0] - 0xf7) as u64;
+    assert(data_len(RlpHeader, lenlen) == 0x016d);
 }
 
 // Test RLP header decoding

--- a/ethereum_history_api/circuits/lib/src/verifiers/account.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/account.nr
@@ -23,42 +23,46 @@ pub(crate) fn assert_account_equals(account_rlp_left_padded: [u8; MAX_ACCOUNT_ST
     let balance = U128::from_integer(account.balance).to_be_bytes();
     let (balance, balance_length) = byte_value(balance);
 
-    assert(account_rlp_list.length[NONCE_INDEX] == nonce_length, "Nonce length mismatch");
+    assert(account_rlp_list.rlp_fragments[NONCE_INDEX].length == nonce_length, "Nonce length mismatch");
     assert(
         sub_array_equals_up_to_length(
             nonce,
             account_rlp_right_padded,
-            account_rlp_list.offset[NONCE_INDEX],
+            account_rlp_list.rlp_fragments[NONCE_INDEX].offset,
             nonce_length as u64
         ), "Nonce mismatch"
     );
 
-    assert(account_rlp_list.length[BALANCE_INDEX] == balance_length, "Balance length mismatch");
+    assert(
+        account_rlp_list.rlp_fragments[BALANCE_INDEX].length == balance_length, "Balance length mismatch"
+    );
     assert(
         sub_array_equals_up_to_length(
             balance,
             account_rlp_right_padded,
-            account_rlp_list.offset[BALANCE_INDEX],
+            account_rlp_list.rlp_fragments[BALANCE_INDEX].offset,
             balance_length as u64
         ), "Balance mismatch"
     );
 
-    assert(account_rlp_list.length[STORAGE_ROOT_INDEX] == HASH_LEN, "Storage root length mismatch");
+    assert(
+        account_rlp_list.rlp_fragments[STORAGE_ROOT_INDEX].length == HASH_LEN, "Storage root length mismatch"
+    );
     assert(
         sub_array_equals_up_to_length(
             account.storage_root,
             account_rlp_right_padded,
-            account_rlp_list.offset[STORAGE_ROOT_INDEX],
+            account_rlp_list.rlp_fragments[STORAGE_ROOT_INDEX].offset,
             HASH_LEN as u64
         ), "Storage root mismatch"
     );
 
-    assert(account_rlp_list.length[CODE_HASH_INDEX] == HASH_LEN, "Code hash length mismatch");
+    assert(account_rlp_list.rlp_fragments[CODE_HASH_INDEX].length == HASH_LEN, "Code hash length mismatch");
     assert(
         sub_array_equals_up_to_length(
             account.code_hash,
             account_rlp_right_padded,
-            account_rlp_list.offset[CODE_HASH_INDEX],
+            account_rlp_list.rlp_fragments[CODE_HASH_INDEX].offset,
             HASH_LEN as u64
         ), "Code hash mismatch"
     );

--- a/ethereum_history_api/circuits/lib/src/verifiers/account.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/account.nr
@@ -3,7 +3,7 @@ use dep::u2b::u64_to_u8;
 
 use crate::account::{Account, StateProof};
 use crate::misc::{arrays::{sub_array_equals_up_to_length, array_equals}, types::{Address, Bytes32}};
-use crate::rlp::decode::{RLP_List, decode_list_of_small_strings};
+use crate::rlp::decode::{RlpList, decode_list_of_small_strings};
 
 use crate::HASH_LEN;
 
@@ -15,7 +15,7 @@ global CODE_HASH_INDEX = 3;
 
 pub(crate) fn assert_account_equals(account_rlp_left_padded: [u8; MAX_ACCOUNT_STATE_LENGTH], account: Account) {
     let account_rlp_right_padded = byte_value(account_rlp_left_padded).0;
-    let account_rlp_list: RLP_List<ACCOUNT_FIELDS_COUNT> = decode_list_of_small_strings(account_rlp_right_padded);
+    let account_rlp_list: RlpList<ACCOUNT_FIELDS_COUNT> = decode_list_of_small_strings(account_rlp_right_padded);
     assert(account_rlp_list.num_fields == ACCOUNT_FIELDS_COUNT, "Invalid number of fields in account RLP");
 
     let nonce = u64_to_u8(account.nonce as u64);
@@ -23,46 +23,44 @@ pub(crate) fn assert_account_equals(account_rlp_left_padded: [u8; MAX_ACCOUNT_ST
     let balance = U128::from_integer(account.balance).to_be_bytes();
     let (balance, balance_length) = byte_value(balance);
 
-    assert(account_rlp_list.rlp_fragments[NONCE_INDEX].length == nonce_length, "Nonce length mismatch");
+    assert(account_rlp_list.fragments[NONCE_INDEX].length == nonce_length, "Nonce length mismatch");
     assert(
         sub_array_equals_up_to_length(
             nonce,
             account_rlp_right_padded,
-            account_rlp_list.rlp_fragments[NONCE_INDEX].offset,
+            account_rlp_list.fragments[NONCE_INDEX].offset,
             nonce_length as u64
         ), "Nonce mismatch"
     );
 
-    assert(
-        account_rlp_list.rlp_fragments[BALANCE_INDEX].length == balance_length, "Balance length mismatch"
-    );
+    assert(account_rlp_list.fragments[BALANCE_INDEX].length == balance_length, "Balance length mismatch");
     assert(
         sub_array_equals_up_to_length(
             balance,
             account_rlp_right_padded,
-            account_rlp_list.rlp_fragments[BALANCE_INDEX].offset,
+            account_rlp_list.fragments[BALANCE_INDEX].offset,
             balance_length as u64
         ), "Balance mismatch"
     );
 
     assert(
-        account_rlp_list.rlp_fragments[STORAGE_ROOT_INDEX].length == HASH_LEN, "Storage root length mismatch"
+        account_rlp_list.fragments[STORAGE_ROOT_INDEX].length == HASH_LEN, "Storage root length mismatch"
     );
     assert(
         sub_array_equals_up_to_length(
             account.storage_root,
             account_rlp_right_padded,
-            account_rlp_list.rlp_fragments[STORAGE_ROOT_INDEX].offset,
+            account_rlp_list.fragments[STORAGE_ROOT_INDEX].offset,
             HASH_LEN as u64
         ), "Storage root mismatch"
     );
 
-    assert(account_rlp_list.rlp_fragments[CODE_HASH_INDEX].length == HASH_LEN, "Code hash length mismatch");
+    assert(account_rlp_list.fragments[CODE_HASH_INDEX].length == HASH_LEN, "Code hash length mismatch");
     assert(
         sub_array_equals_up_to_length(
             account.code_hash,
             account_rlp_right_padded,
-            account_rlp_list.rlp_fragments[CODE_HASH_INDEX].offset,
+            account_rlp_list.fragments[CODE_HASH_INDEX].offset,
             HASH_LEN as u64
         ), "Code hash mismatch"
     );

--- a/ethereum_history_api/circuits/lib/src/verifiers/header.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/header.nr
@@ -51,13 +51,13 @@ pub fn verify_header(
     let (block_number, block_number_length) = byte_value(block_number);
 
     assert(
-        header_rlp_list.length[BLOCK_NUM_INDEX] == block_number_length, "block number length does not match"
+        header_rlp_list.rlp_fragments[BLOCK_NUM_INDEX].length == block_number_length, "block number length does not match"
     );
     assert(
         sub_array_equals_up_to_length(
             block_number,
             block_header_rlp.data,
-            header_rlp_list.offset[BLOCK_NUM_INDEX],
+            header_rlp_list.rlp_fragments[BLOCK_NUM_INDEX].offset,
             block_number_length as u64
         ), "block number does not match"
     );
@@ -72,21 +72,21 @@ pub fn verify_header(
         sub_array_equals(
             block_header_partial.state_root,
             block_header_rlp.data,
-            header_rlp_list.offset[STATE_ROOT_INDEX]
+            header_rlp_list.rlp_fragments[STATE_ROOT_INDEX].offset
         ), "state_root does not match"
     );
     assert(
         sub_array_equals(
             block_header_partial.transactions_root,
             block_header_rlp.data,
-            header_rlp_list.offset[TRANSACTIONS_ROOT_INDEX]
+            header_rlp_list.rlp_fragments[TRANSACTIONS_ROOT_INDEX].offset
         ), "transactions_root does not match"
     );
     assert(
         sub_array_equals(
             block_header_partial.receipts_root,
             block_header_rlp.data,
-            header_rlp_list.offset[RECEIPTS_ROOT_INDEX]
+            header_rlp_list.rlp_fragments[RECEIPTS_ROOT_INDEX].offset
         ), "receipts_root does not match"
     );
 }

--- a/ethereum_history_api/circuits/lib/src/verifiers/header.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/header.nr
@@ -4,7 +4,7 @@ use dep::u2b::u64_to_u8;
 
 use crate::header::{BlockHeaderPartial, BlockHeaderRlp, ETHEREUM_MAINNET_ID, ETHEREUM_SEPOLIA_ID};
 use crate::misc::arrays::{sub_array_equals, sub_array_equals_up_to_length};
-use crate::rlp::decode::{decode_list, RLP_List};
+use crate::rlp::decode::{decode_list, RlpList};
 
 global MAX_HEADER_FIELDS_COUNT = 20;
 global STATE_ROOT_INDEX = 3;
@@ -39,7 +39,7 @@ pub fn verify_header(
     block_header_partial: BlockHeaderPartial,
     block_header_rlp: BlockHeaderRlp
 ) {
-    let header_rlp_list: RLP_List<MAX_HEADER_FIELDS_COUNT> = decode_list(block_header_rlp.data);
+    let header_rlp_list: RlpList<MAX_HEADER_FIELDS_COUNT> = decode_list(block_header_rlp.data);
     let expected_header_fields_count = get_header_fields_count(chain_id, block_header_partial.number as u64);
 
     assert(
@@ -51,13 +51,13 @@ pub fn verify_header(
     let (block_number, block_number_length) = byte_value(block_number);
 
     assert(
-        header_rlp_list.rlp_fragments[BLOCK_NUM_INDEX].length == block_number_length, "block number length does not match"
+        header_rlp_list.fragments[BLOCK_NUM_INDEX].length == block_number_length, "block number length does not match"
     );
     assert(
         sub_array_equals_up_to_length(
             block_number,
             block_header_rlp.data,
-            header_rlp_list.rlp_fragments[BLOCK_NUM_INDEX].offset,
+            header_rlp_list.fragments[BLOCK_NUM_INDEX].offset,
             block_number_length as u64
         ), "block number does not match"
     );
@@ -72,21 +72,21 @@ pub fn verify_header(
         sub_array_equals(
             block_header_partial.state_root,
             block_header_rlp.data,
-            header_rlp_list.rlp_fragments[STATE_ROOT_INDEX].offset
+            header_rlp_list.fragments[STATE_ROOT_INDEX].offset
         ), "state_root does not match"
     );
     assert(
         sub_array_equals(
             block_header_partial.transactions_root,
             block_header_rlp.data,
-            header_rlp_list.rlp_fragments[TRANSACTIONS_ROOT_INDEX].offset
+            header_rlp_list.fragments[TRANSACTIONS_ROOT_INDEX].offset
         ), "transactions_root does not match"
     );
     assert(
         sub_array_equals(
             block_header_partial.receipts_root,
             block_header_rlp.data,
-            header_rlp_list.rlp_fragments[RECEIPTS_ROOT_INDEX].offset
+            header_rlp_list.fragments[RECEIPTS_ROOT_INDEX].offset
         ), "receipts_root does not match"
     );
 }

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
@@ -4,7 +4,7 @@ use crate::{
 };
 use dep::proof::{const::HASH_LENGTH, utils::byte_value};
 use crate::misc::arrays::sub_array_equals_up_to_length;
-use crate::rlp::decode::{RLP_List, decode_list, STRING};
+use crate::rlp::decode::{RlpList, decode_list, STRING};
 use dep::u2b::u32_to_u8;
 
 global RECEIPT_FIELDS_COUNT = 4;
@@ -18,59 +18,57 @@ pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
     receipt_rlp: [u8; MAX_RECEIPT_RLP_LENGTH],
     receipt: TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>
 ) {
-    let receipt_rlp_list: RLP_List<RECEIPT_FIELDS_COUNT> = decode_list(receipt_rlp);
+    let receipt_rlp_list: RlpList<RECEIPT_FIELDS_COUNT> = decode_list(receipt_rlp);
     assert(receipt_rlp_list.num_fields == RECEIPT_FIELDS_COUNT, "Invalid number of fields in receipt RLP");
 
     if (is_pre_byzantium) {
+        assert(receipt_rlp_list.fragments[STATE_ROOT_INDEX].data_type == STRING, "Invalid state root type");
         assert(
-            receipt_rlp_list.rlp_fragments[STATE_ROOT_INDEX].data_type == STRING, "Invalid state root type"
-        );
-        assert(
-            receipt_rlp_list.rlp_fragments[STATE_ROOT_INDEX].length == HASH_LENGTH, "Invalid state root length"
+            receipt_rlp_list.fragments[STATE_ROOT_INDEX].length == HASH_LENGTH, "Invalid state root length"
         );
         assert(
             sub_array_equals_up_to_length(
                 receipt.state_root.expect(f"State root is missing"),
                 receipt_rlp,
-                receipt_rlp_list.rlp_fragments[STATE_ROOT_INDEX].offset,
+                receipt_rlp_list.fragments[STATE_ROOT_INDEX].offset,
                 HASH_LENGTH as u64
             ), "State root mismatch"
         );
     } else {
         let status = receipt.status.expect(f"Status is missing");
-        assert(receipt_rlp_list.rlp_fragments[STATUS_INDEX].data_type == STRING, "Invalid status type");
-        assert(receipt_rlp_list.rlp_fragments[STATUS_INDEX].length == 1, "Invalid status length");
+        assert(receipt_rlp_list.fragments[STATUS_INDEX].data_type == STRING, "Invalid status type");
+        assert(receipt_rlp_list.fragments[STATUS_INDEX].length == 1, "Invalid status length");
         assert(
-            receipt_rlp[receipt_rlp_list.rlp_fragments[STATUS_INDEX].offset] as u1 == status, "Status mismatch"
+            receipt_rlp[receipt_rlp_list.fragments[STATUS_INDEX].offset] as u1 == status, "Status mismatch"
         );
     }
 
     let cumulative_gas_used = u32_to_u8(receipt.cumulative_gas_used as u32);
     let (cumulative_gas_used, cumulative_gas_used_length) = byte_value(cumulative_gas_used);
     assert(
-        receipt_rlp_list.rlp_fragments[CUMULATIVE_GAS_USED_INDEX].data_type == STRING, "Invalid cumulative gas used type"
+        receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].data_type == STRING, "Invalid cumulative gas used type"
     );
     assert(
-        receipt_rlp_list.rlp_fragments[CUMULATIVE_GAS_USED_INDEX].length == cumulative_gas_used_length, "Invalid cumulative gas used length"
+        receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].length == cumulative_gas_used_length, "Invalid cumulative gas used length"
     );
     assert(
         sub_array_equals_up_to_length(
             cumulative_gas_used,
             receipt_rlp,
-            receipt_rlp_list.rlp_fragments[CUMULATIVE_GAS_USED_INDEX].offset,
+            receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].offset,
             cumulative_gas_used_length as u64
         ), "Cumulative gas used mismatch"
     );
 
-    assert(receipt_rlp_list.rlp_fragments[LOGS_BLOOM_INDEX].data_type == STRING, "Invalid logs bloom type");
+    assert(receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].data_type == STRING, "Invalid logs bloom type");
     assert(
-        receipt_rlp_list.rlp_fragments[LOGS_BLOOM_INDEX].length == BLOOM_FILTER_LEN, "Invalid logs bloom length"
+        receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].length == BLOOM_FILTER_LEN, "Invalid logs bloom length"
     );
     assert(
         sub_array_equals_up_to_length(
             receipt.logs_bloom,
             receipt_rlp,
-            receipt_rlp_list.rlp_fragments[LOGS_BLOOM_INDEX].offset,
+            receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].offset,
             BLOOM_FILTER_LEN as u64
         ), "Logs bloom mismatch"
     );

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
@@ -22,47 +22,55 @@ pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
     assert(receipt_rlp_list.num_fields == RECEIPT_FIELDS_COUNT, "Invalid number of fields in receipt RLP");
 
     if (is_pre_byzantium) {
-        assert(receipt_rlp_list.data_type[STATE_ROOT_INDEX] == STRING, "Invalid state root type");
-        assert(receipt_rlp_list.length[STATE_ROOT_INDEX] == HASH_LENGTH, "Invalid state root length");
+        assert(
+            receipt_rlp_list.rlp_fragments[STATE_ROOT_INDEX].data_type == STRING, "Invalid state root type"
+        );
+        assert(
+            receipt_rlp_list.rlp_fragments[STATE_ROOT_INDEX].length == HASH_LENGTH, "Invalid state root length"
+        );
         assert(
             sub_array_equals_up_to_length(
                 receipt.state_root.expect(f"State root is missing"),
                 receipt_rlp,
-                receipt_rlp_list.offset[STATE_ROOT_INDEX],
+                receipt_rlp_list.rlp_fragments[STATE_ROOT_INDEX].offset,
                 HASH_LENGTH as u64
             ), "State root mismatch"
         );
     } else {
         let status = receipt.status.expect(f"Status is missing");
-        assert(receipt_rlp_list.data_type[STATUS_INDEX] == STRING, "Invalid status type");
-        assert(receipt_rlp_list.length[STATUS_INDEX] == 1, "Invalid status length");
-        assert(receipt_rlp[receipt_rlp_list.offset[STATUS_INDEX]] as u1 == status, "Status mismatch");
+        assert(receipt_rlp_list.rlp_fragments[STATUS_INDEX].data_type == STRING, "Invalid status type");
+        assert(receipt_rlp_list.rlp_fragments[STATUS_INDEX].length == 1, "Invalid status length");
+        assert(
+            receipt_rlp[receipt_rlp_list.rlp_fragments[STATUS_INDEX].offset] as u1 == status, "Status mismatch"
+        );
     }
 
     let cumulative_gas_used = u32_to_u8(receipt.cumulative_gas_used as u32);
     let (cumulative_gas_used, cumulative_gas_used_length) = byte_value(cumulative_gas_used);
     assert(
-        receipt_rlp_list.data_type[CUMULATIVE_GAS_USED_INDEX] == STRING, "Invalid cumulative gas used type"
+        receipt_rlp_list.rlp_fragments[CUMULATIVE_GAS_USED_INDEX].data_type == STRING, "Invalid cumulative gas used type"
     );
     assert(
-        receipt_rlp_list.length[CUMULATIVE_GAS_USED_INDEX] == cumulative_gas_used_length, "Invalid cumulative gas used length"
+        receipt_rlp_list.rlp_fragments[CUMULATIVE_GAS_USED_INDEX].length == cumulative_gas_used_length, "Invalid cumulative gas used length"
     );
     assert(
         sub_array_equals_up_to_length(
             cumulative_gas_used,
             receipt_rlp,
-            receipt_rlp_list.offset[CUMULATIVE_GAS_USED_INDEX],
+            receipt_rlp_list.rlp_fragments[CUMULATIVE_GAS_USED_INDEX].offset,
             cumulative_gas_used_length as u64
         ), "Cumulative gas used mismatch"
     );
 
-    assert(receipt_rlp_list.data_type[LOGS_BLOOM_INDEX] == STRING, "Invalid logs bloom type");
-    assert(receipt_rlp_list.length[LOGS_BLOOM_INDEX] == BLOOM_FILTER_LEN, "Invalid logs bloom length");
+    assert(receipt_rlp_list.rlp_fragments[LOGS_BLOOM_INDEX].data_type == STRING, "Invalid logs bloom type");
+    assert(
+        receipt_rlp_list.rlp_fragments[LOGS_BLOOM_INDEX].length == BLOOM_FILTER_LEN, "Invalid logs bloom length"
+    );
     assert(
         sub_array_equals_up_to_length(
             receipt.logs_bloom,
             receipt_rlp,
-            receipt_rlp_list.offset[LOGS_BLOOM_INDEX],
+            receipt_rlp_list.rlp_fragments[LOGS_BLOOM_INDEX].offset,
             BLOOM_FILTER_LEN as u64
         ), "Logs bloom mismatch"
     );


### PR DESCRIPTION
Transpose RLP_List structure to have an array of N structs of length 3 instead of three arrays of N elements.