### PR TITLE
Reasonable rlp

### DIFF
--- a/ethereum_history_api/circuits/lib/src/misc/types.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/types.nr
@@ -1,2 +1,13 @@
 type Address = [u8; 20];
 type Bytes32 = [u8; 32];
+
+struct PaddedValue<MAX_LEN> {
+    value: [u8; MAX_LEN],
+    length: u64,
+}
+
+impl<MAX_LEN> From<([u8; MAX_LEN], u64)> for PaddedValue<MAX_LEN> {
+    fn from((value, length): ([u8; MAX_LEN], u64)) -> Self {
+        Self { value, length }
+    }
+}

--- a/ethereum_history_api/circuits/lib/src/receipt.nr
+++ b/ethereum_history_api/circuits/lib/src/receipt.nr
@@ -4,7 +4,7 @@ use crate::verifiers::receipt::{MAX_ENCODED_RECEIPT_LENGTH, verify_receipt};
 use dep::std::unsafe::zeroed;
 use dep::proof::receipt_proof::ReceiptProof;
 
-global BLOOM_FILTER_LEN = 256;
+global BLOOM_FILTER_LEN: u64 = 256;
 global MAX_RECEIPT_KEY_LEN = 3;
 global MAX_RECEIPT_TREE_DEPTH = 7;
 
@@ -22,7 +22,7 @@ struct PhantomReceiptRlpLen<MAX_RECEIPT_ENCODED_LEN> {}
 struct TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN> {
     status: Option<u1>,
     state_root: Option<Bytes32>,
-    cumulative_gas_used: Field,
+    cumulative_gas_used: u32,
     logs_bloom: [u8; BLOOM_FILTER_LEN]
 }
 
@@ -31,7 +31,7 @@ struct ForeignCallTxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN> {
     status_is_some: bool,
     state_root: Bytes32,
     state_root_is_some: bool,
-    cumulative_gas_used: Field,
+    cumulative_gas_used: u32,
     logs_bloom: [u8; BLOOM_FILTER_LEN]
 }
 

--- a/ethereum_history_api/circuits/lib/src/rlp.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp.nr
@@ -1,2 +1,4 @@
 mod decode;
 mod decode_test;
+mod fragment;
+mod fragment_test;

--- a/ethereum_history_api/circuits/lib/src/rlp/decode.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/decode.nr
@@ -1,4 +1,5 @@
 use dep::std::wrapping_sub;
+use crate::rlp::fragment::RlpFragment;
 
 /// Max number of bytes required to represent length of a string or list
 global MAX_LEN_IN_BYTES: u64 = 2;
@@ -11,24 +12,6 @@ struct RlpHeader {
     offset: u64,
     length: u64, 
     data_type: u64 // STRING or LIST    
-}
-
-struct RlpFragment {
-    offset: u64,
-    length: u64,    
-    data_type: u64 // STRING or LIST
-}
-
-impl Default for RlpFragment {
-    fn default() -> Self {
-        RlpFragment { offset: 0, length: 0, data_type: 0 }
-    }
-}
-
-impl Eq for RlpFragment {
-    fn eq(self, other: Self) -> bool {
-        (self.offset == other.offset) & (self.length == other.length) & (self.data_type == other.data_type)
-    }
 }
 
 struct RlpList<NUM_FIELDS> {

--- a/ethereum_history_api/circuits/lib/src/rlp/decode_test.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/decode_test.nr
@@ -89,7 +89,7 @@ mod test_decode_string {
 }
 
 mod test_decode_list {
-    use crate::rlp::decode::{decode_list, RlpList, RlpFragment, STRING};
+    use crate::rlp::{decode::{decode_list, RlpList, STRING}, fragment::RlpFragment};
 
     #[test]
     fn empty() {

--- a/ethereum_history_api/circuits/lib/src/rlp/fragment.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/fragment.nr
@@ -1,0 +1,35 @@
+use crate::misc::{arrays::sub_array_equals_up_to_length, types::PaddedValue};
+use crate::rlp::decode::STRING;
+
+struct RlpFragment {
+    offset: u64,
+    length: u64,    
+    data_type: u64 // STRING or LIST
+}
+
+impl RlpFragment {
+    fn assert_string_eq<FIELD_NAME_LEN, MAX_RLP_LEN, MAX_VALUE_LEN>(
+        self,
+        field_name: str<FIELD_NAME_LEN>,
+        rlp: [u8; MAX_RLP_LEN],
+        value: PaddedValue<MAX_VALUE_LEN>
+    ) {
+        assert(self.data_type == STRING, f"{field_name}: Invalid RLP type");
+        assert(self.length == value.length, f"{field_name}: Invalid RLP length");
+        assert(
+            sub_array_equals_up_to_length(value.value, rlp, self.offset, value.length), f"{field_name}: Invalid RLP value"
+        );
+    }
+}
+
+impl Default for RlpFragment {
+    fn default() -> Self {
+        RlpFragment { offset: 0, length: 0, data_type: 0 }
+    }
+}
+
+impl Eq for RlpFragment {
+    fn eq(self, other: Self) -> bool {
+        (self.offset == other.offset) & (self.length == other.length) & (self.data_type == other.data_type)
+    }
+}

--- a/ethereum_history_api/circuits/lib/src/rlp/fragment_test.nr
+++ b/ethereum_history_api/circuits/lib/src/rlp/fragment_test.nr
@@ -1,0 +1,43 @@
+use crate::rlp::{decode::{STRING, LIST}, fragment::RlpFragment};
+
+#[test]
+fn success_short() {
+    let fragment = RlpFragment { offset: 0, length: 1, data_type: STRING };
+    let rlp = [0x42]; // "0x42"
+    let value: [u8; 1] = [0x42];
+    fragment.assert_string_eq("Field", rlp, Into::into((value, value.len())))
+}
+
+#[test]
+fn success() {
+    let fragment = RlpFragment { offset: 1, length: 2, data_type: STRING };
+    let rlp = [0x82, 0x12, 0x34]; // "0x1234"
+    let value: [u8; 2] = [0x12, 0x34];
+    fragment.assert_string_eq("Field", rlp, Into::into((value, value.len())))
+}
+
+#[test(should_fail_with = "Field: Invalid RLP type")]
+fn invalid_type() {
+    let invalid_type = LIST;
+    let fragment = RlpFragment { offset: 1, length: 0, data_type: invalid_type };
+    let rlp = [0xc0]; // []
+    let value: [u8; 0] = [];
+    fragment.assert_string_eq("Field", rlp, Into::into((value, value.len())))
+}
+
+#[test(should_fail_with = "Field: Invalid RLP length")]
+fn invalid_length() {
+    let invalid_length = 1;
+    let fragment = RlpFragment { offset: 1, length: invalid_length, data_type: STRING };
+    let rlp = [0x82, 0x12, 0x34]; // "0x1234"
+    let value: [u8; 2] = [0x12, 0x34];
+    fragment.assert_string_eq("Field", rlp, Into::into((value, value.len())))
+}
+
+#[test(should_fail_with = "Field: Invalid RLP value")]
+fn invalid_value() {
+    let fragment = RlpFragment { offset: 1, length: 2, data_type: STRING };
+    let rlp = [0x82, 0x12, 0x34]; // "0x1234"
+    let invalid_value: [u8; 2] = [0x00, 0x00];
+    fragment.assert_string_eq("Field", rlp, Into::into((invalid_value, invalid_value.len())))
+}

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
@@ -5,7 +5,8 @@ use crate::{
 use dep::proof::const::HASH_LENGTH;
 use crate::misc::arrays::sub_array_equals_up_to_length;
 use crate::misc::bytes::byte_value;
-use crate::rlp::decode::{RlpList, decode_list, STRING, RlpFragment};
+use crate::misc::types::PaddedValue;
+use crate::rlp::decode::{RlpList, decode_list, STRING};
 use dep::u2b::u32_to_u8;
 
 global RECEIPT_FIELDS_COUNT = 4;
@@ -13,30 +14,6 @@ global STATE_ROOT_INDEX = 0;
 global STATUS_INDEX = 0;
 global CUMULATIVE_GAS_USED_INDEX = 1;
 global LOGS_BLOOM_INDEX = 2;
-
-struct PaddedValue<MAX_LEN> {
-    value: [u8; MAX_LEN],
-    length: u64,
-}
-
-impl<MAX_LEN> From<([u8; MAX_LEN], u64)> for PaddedValue<MAX_LEN> {
-    fn from((value, length): ([u8; MAX_LEN], u64)) -> Self {
-        Self { value, length }
-    }
-}
-
-fn assert_rlp_fragment<FIELD_NAME_LEN, MAX_RLP_LEN, MAX_VALUE_LEN>(
-    field_name: str<FIELD_NAME_LEN>,
-    fragment: RlpFragment,
-    rlp: [u8; MAX_RLP_LEN],
-    value: PaddedValue<MAX_VALUE_LEN>
-) {
-    assert(fragment.data_type == STRING, f"{field_name}: Invalid RLP type");
-    assert(fragment.length == value.length, f"{field_name}: Invalid RLP length");
-    assert(
-        sub_array_equals_up_to_length(value.value, rlp, fragment.offset, value.length), f"{field_name}: Invalid RLP value"
-    );
-}
 
 pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
     is_pre_byzantium: bool,
@@ -47,32 +24,28 @@ pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
     assert(receipt_rlp_list.num_fields == RECEIPT_FIELDS_COUNT, "Invalid number of fields in receipt RLP");
 
     if (is_pre_byzantium) {
-        assert_rlp_fragment(
+        receipt_rlp_list.fragments[STATE_ROOT_INDEX].assert_string_eq(
             "State root",
-            receipt_rlp_list.fragments[STATE_ROOT_INDEX],
             receipt_rlp,
             Into::into((receipt.state_root.expect(f"State root is missing"), HASH_LENGTH))
         );
     } else {
-        assert_rlp_fragment(
+        receipt_rlp_list.fragments[STATUS_INDEX].assert_string_eq(
             "Status",
-            receipt_rlp_list.fragments[STATUS_INDEX],
             receipt_rlp,
             Into::into(([receipt.status.expect(f"Status is missing") as u8], 1 as u64))
         );
     }
 
     let cumulative_gas_used = u32_to_u8(receipt.cumulative_gas_used);
-    assert_rlp_fragment(
+    receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].assert_string_eq(
         "Cumulative gas used",
-        receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX],
         receipt_rlp,
         Into::into(byte_value(cumulative_gas_used))
     );
 
-    assert_rlp_fragment(
+    receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].assert_string_eq(
         "Logs bloom",
-        receipt_rlp_list.fragments[LOGS_BLOOM_INDEX],
         receipt_rlp,
         Into::into((receipt.logs_bloom, BLOOM_FILTER_LEN))
     );

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
@@ -5,7 +5,7 @@ use crate::{
 use dep::proof::const::HASH_LENGTH;
 use crate::misc::arrays::sub_array_equals_up_to_length;
 use crate::misc::bytes::byte_value;
-use crate::rlp::decode::{RlpList, decode_list, STRING};
+use crate::rlp::decode::{RlpList, decode_list, STRING, RlpFragment};
 use dep::u2b::u32_to_u8;
 
 global RECEIPT_FIELDS_COUNT = 4;
@@ -13,6 +13,30 @@ global STATE_ROOT_INDEX = 0;
 global STATUS_INDEX = 0;
 global CUMULATIVE_GAS_USED_INDEX = 1;
 global LOGS_BLOOM_INDEX = 2;
+
+struct PaddedValue<MAX_LEN> {
+    value: [u8; MAX_LEN],
+    length: u64,
+}
+
+impl<MAX_LEN> From<([u8; MAX_LEN], u64)> for PaddedValue<MAX_LEN> {
+    fn from((value, length): ([u8; MAX_LEN], u64)) -> Self {
+        Self { value, length }
+    }
+}
+
+fn assert_rlp_fragment<FIELD_NAME_LEN, MAX_RLP_LEN, MAX_VALUE_LEN>(
+    field_name: str<FIELD_NAME_LEN>,
+    fragment: RlpFragment,
+    rlp: [u8; MAX_RLP_LEN],
+    value: PaddedValue<MAX_VALUE_LEN>
+) {
+    assert(fragment.data_type == STRING, f"{field_name}: Invalid RLP type");
+    assert(fragment.length == value.length, f"{field_name}: Invalid RLP length");
+    assert(
+        sub_array_equals_up_to_length(value.value, rlp, fragment.offset, value.length), f"{field_name}: Invalid RLP value"
+    );
+}
 
 pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
     is_pre_byzantium: bool,
@@ -23,54 +47,33 @@ pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
     assert(receipt_rlp_list.num_fields == RECEIPT_FIELDS_COUNT, "Invalid number of fields in receipt RLP");
 
     if (is_pre_byzantium) {
-        assert(receipt_rlp_list.fragments[STATE_ROOT_INDEX].data_type == STRING, "Invalid state root type");
-        assert(
-            receipt_rlp_list.fragments[STATE_ROOT_INDEX].length == HASH_LENGTH, "Invalid state root length"
-        );
-        assert(
-            sub_array_equals_up_to_length(
-                receipt.state_root.expect(f"State root is missing"),
-                receipt_rlp,
-                receipt_rlp_list.fragments[STATE_ROOT_INDEX].offset,
-                HASH_LENGTH as u64
-            ), "State root mismatch"
+        assert_rlp_fragment(
+            "State root",
+            receipt_rlp_list.fragments[STATE_ROOT_INDEX],
+            receipt_rlp,
+            Into::into((receipt.state_root.expect(f"State root is missing"), HASH_LENGTH))
         );
     } else {
-        let status = receipt.status.expect(f"Status is missing");
-        assert(receipt_rlp_list.fragments[STATUS_INDEX].data_type == STRING, "Invalid status type");
-        assert(receipt_rlp_list.fragments[STATUS_INDEX].length == 1, "Invalid status length");
-        assert(
-            receipt_rlp[receipt_rlp_list.fragments[STATUS_INDEX].offset] as u1 == status, "Status mismatch"
+        assert_rlp_fragment(
+            "Status",
+            receipt_rlp_list.fragments[STATUS_INDEX],
+            receipt_rlp,
+            Into::into(([receipt.status.expect(f"Status is missing") as u8], 1 as u64))
         );
     }
 
-    let cumulative_gas_used = u32_to_u8(receipt.cumulative_gas_used as u32);
-    let (cumulative_gas_used, cumulative_gas_used_length) = byte_value(cumulative_gas_used);
-    assert(
-        receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].data_type == STRING, "Invalid cumulative gas used type"
-    );
-    assert(
-        receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].length == cumulative_gas_used_length, "Invalid cumulative gas used length"
-    );
-    assert(
-        sub_array_equals_up_to_length(
-            cumulative_gas_used,
-            receipt_rlp,
-            receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX].offset,
-            cumulative_gas_used_length as u64
-        ), "Cumulative gas used mismatch"
+    let cumulative_gas_used = u32_to_u8(receipt.cumulative_gas_used);
+    assert_rlp_fragment(
+        "Cumulative gas used",
+        receipt_rlp_list.fragments[CUMULATIVE_GAS_USED_INDEX],
+        receipt_rlp,
+        Into::into(byte_value(cumulative_gas_used))
     );
 
-    assert(receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].data_type == STRING, "Invalid logs bloom type");
-    assert(
-        receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].length == BLOOM_FILTER_LEN, "Invalid logs bloom length"
-    );
-    assert(
-        sub_array_equals_up_to_length(
-            receipt.logs_bloom,
-            receipt_rlp,
-            receipt_rlp_list.fragments[LOGS_BLOOM_INDEX].offset,
-            BLOOM_FILTER_LEN as u64
-        ), "Logs bloom mismatch"
+    assert_rlp_fragment(
+        "Logs bloom",
+        receipt_rlp_list.fragments[LOGS_BLOOM_INDEX],
+        receipt_rlp,
+        Into::into((receipt.logs_bloom, BLOOM_FILTER_LEN))
     );
 }

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp_test.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp_test.nr
@@ -29,13 +29,13 @@ fn test_assert_receipt_rlp_equals_invalid_rlp_field_count() {
     assert_receipt_rlp_equals(false, resize(list_with_single_string), receipt);
 }
 
-#[test(should_fail_with="Invalid state root type")]
+#[test(should_fail_with="State root: Invalid RLP type")]
 fn test_assert_receipt_rlp_equals_invalid_state_root_type() {
     let state_root_is_a_list = [0xc4, 0xc0, 0x80, 0x80, 0x80]; // [[], "", "", ""]
     assert_receipt_rlp_equals(true, resize(state_root_is_a_list), pre_byzantium_receipt);
 }
 
-#[test(should_fail_with="Invalid state root length")]
+#[test(should_fail_with="State root: Invalid RLP length")]
 fn test_assert_receipt_rlp_equals_invalid_state_root_length() {
     let state_root_too_short = [0xc4, 0x80, 0x80, 0x80, 0x80]; // ["", "", "", ""]
     assert_receipt_rlp_equals(true, resize(state_root_too_short), pre_byzantium_receipt);
@@ -48,20 +48,20 @@ fn test_assert_receipt_rlp_equals_missing_state_root() {
     assert_receipt_rlp_equals(true, pre_byzantium_receipt_rlp, receipt);
 }
 
-#[test(should_fail_with="State root mismatch")]
+#[test(should_fail_with="State root: Invalid RLP value")]
 fn test_assert_receipt_rlp_equals_invalid_state_root_value() {
     let mut receipt = pre_byzantium_receipt;
     receipt.state_root = receipt.state_root.map(alter_array);
     assert_receipt_rlp_equals(true, pre_byzantium_receipt_rlp, receipt);
 }
 
-#[test(should_fail_with="Invalid status type")]
+#[test(should_fail_with="Status: Invalid RLP type")]
 fn test_assert_receipt_rlp_equals_invalid_status_type() {
     let status_is_a_list = [0xc4, 0xc0, 0x80, 0x80, 0x80]; // [[], "", "", ""]
     assert_receipt_rlp_equals(false, resize(status_is_a_list), receipt);
 }
 
-#[test(should_fail_with="Invalid status length")]
+#[test(should_fail_with="Status: Invalid RLP length")]
 fn test_assert_receipt_rlp_equals_invalid_status_length() {
     let status_too_short = [0xc4, 0x80, 0x80, 0x80, 0x80]; // ["", "", "", ""]
     assert_receipt_rlp_equals(false, resize(status_too_short), receipt);
@@ -74,45 +74,45 @@ fn test_assert_receipt_rlp_equals_missing_status() {
     assert_receipt_rlp_equals(false, receipt_rlp, receipt);
 }
 
-#[test(should_fail_with="Status mismatch")]
+#[test(should_fail_with="Status: Invalid RLP value")]
 fn test_assert_receipt_rlp_equals_invalid_status_value() {
     let mut receipt = receipt;
     receipt.status = receipt.status.map(|status| 1 - status);
     assert_receipt_rlp_equals(false, receipt_rlp, receipt);
 }
 
-#[test(should_fail_with="Invalid cumulative gas used type")]
+#[test(should_fail_with="Cumulative gas used: Invalid RLP type")]
 fn test_assert_receipt_rlp_equals_invalid_cumulative_gas_used_type() {
     let cumulative_gas_used_is_a_list = [0xc4, 0x01, 0xc0, 0x80, 0x80]; // ["0x01", [], "", ""]
     assert_receipt_rlp_equals(false, resize(cumulative_gas_used_is_a_list), receipt);
 }
 
-#[test(should_fail_with="Invalid cumulative gas used length")]
+#[test(should_fail_with="Cumulative gas used: Invalid RLP length")]
 fn test_assert_receipt_rlp_equals_invalid_cumulative_gas_used_length() {
     let cumulative_gas_used_too_short = [0xc4, 0x01, 0x80, 0x80, 0x80]; // ["0x01", "", "", ""]
     assert_receipt_rlp_equals(false, resize(cumulative_gas_used_too_short), receipt);
 }
 
-#[test(should_fail_with="Cumulative gas used mismatch")]
+#[test(should_fail_with="Cumulative gas used: Invalid RLP value)]
 fn test_assert_receipt_rlp_equals_invalid_cumulative_gas_used_value() {
     let mut receipt = receipt;
     receipt.cumulative_gas_used = wrapping_add(receipt.cumulative_gas_used, 1);
     assert_receipt_rlp_equals(false, receipt_rlp, receipt);
 }
 
-#[test(should_fail_with="Invalid logs bloom type")]
+#[test(should_fail_with="Logs bloom: Invalid RLP type")]
 fn test_assert_receipt_rlp_equals_invalid_logs_bloom_type() {
     let logs_bloom_is_a_list = [0xc7, 0x01, 0x83, 0x0a, 0x17, 0xe1, 0xc0, 0x80]; // ["0x01", "0x0a17e1", [], ""]
     assert_receipt_rlp_equals(false, resize(logs_bloom_is_a_list), receipt);
 }
 
-#[test(should_fail_with="Invalid logs bloom length")]
+#[test(should_fail_with="Logs bloom: Invalid RLP length")]
 fn test_assert_receipt_rlp_equals_invalid_logs_bloom_length() {
     let logs_bloom_too_short = [0xc7, 0x01, 0x83, 0x0a, 0x17, 0xe1, 0x80, 0x80]; // ["0x01", "0x0a17e1", "", ""]
     assert_receipt_rlp_equals(false, resize(logs_bloom_too_short), receipt);
 }
 
-#[test(should_fail_with="Logs bloom mismatch")]
+#[test(should_fail_with="Logs bloom: Invalid RLP value")]
 fn test_assert_receipt_rlp_equals_invalid_logs_bloom_value() {
     let mut receipt = receipt;
     receipt.logs_bloom = alter_array(receipt.logs_bloom);

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp_test.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp_test.nr
@@ -29,18 +29,6 @@ fn test_assert_receipt_rlp_equals_invalid_rlp_field_count() {
     assert_receipt_rlp_equals(false, resize(list_with_single_string), receipt);
 }
 
-#[test(should_fail_with="State root: Invalid RLP type")]
-fn test_assert_receipt_rlp_equals_invalid_state_root_type() {
-    let state_root_is_a_list = [0xc4, 0xc0, 0x80, 0x80, 0x80]; // [[], "", "", ""]
-    assert_receipt_rlp_equals(true, resize(state_root_is_a_list), pre_byzantium_receipt);
-}
-
-#[test(should_fail_with="State root: Invalid RLP length")]
-fn test_assert_receipt_rlp_equals_invalid_state_root_length() {
-    let state_root_too_short = [0xc4, 0x80, 0x80, 0x80, 0x80]; // ["", "", "", ""]
-    assert_receipt_rlp_equals(true, resize(state_root_too_short), pre_byzantium_receipt);
-}
-
 #[test(should_fail_with="State root is missing")]
 fn test_assert_receipt_rlp_equals_missing_state_root() {
     let mut receipt = pre_byzantium_receipt;
@@ -53,18 +41,6 @@ fn test_assert_receipt_rlp_equals_invalid_state_root_value() {
     let mut receipt = pre_byzantium_receipt;
     receipt.state_root = receipt.state_root.map(alter_array);
     assert_receipt_rlp_equals(true, pre_byzantium_receipt_rlp, receipt);
-}
-
-#[test(should_fail_with="Status: Invalid RLP type")]
-fn test_assert_receipt_rlp_equals_invalid_status_type() {
-    let status_is_a_list = [0xc4, 0xc0, 0x80, 0x80, 0x80]; // [[], "", "", ""]
-    assert_receipt_rlp_equals(false, resize(status_is_a_list), receipt);
-}
-
-#[test(should_fail_with="Status: Invalid RLP length")]
-fn test_assert_receipt_rlp_equals_invalid_status_length() {
-    let status_too_short = [0xc4, 0x80, 0x80, 0x80, 0x80]; // ["", "", "", ""]
-    assert_receipt_rlp_equals(false, resize(status_too_short), receipt);
 }
 
 #[test(should_fail_with="Status is missing")]
@@ -81,35 +57,11 @@ fn test_assert_receipt_rlp_equals_invalid_status_value() {
     assert_receipt_rlp_equals(false, receipt_rlp, receipt);
 }
 
-#[test(should_fail_with="Cumulative gas used: Invalid RLP type")]
-fn test_assert_receipt_rlp_equals_invalid_cumulative_gas_used_type() {
-    let cumulative_gas_used_is_a_list = [0xc4, 0x01, 0xc0, 0x80, 0x80]; // ["0x01", [], "", ""]
-    assert_receipt_rlp_equals(false, resize(cumulative_gas_used_is_a_list), receipt);
-}
-
-#[test(should_fail_with="Cumulative gas used: Invalid RLP length")]
-fn test_assert_receipt_rlp_equals_invalid_cumulative_gas_used_length() {
-    let cumulative_gas_used_too_short = [0xc4, 0x01, 0x80, 0x80, 0x80]; // ["0x01", "", "", ""]
-    assert_receipt_rlp_equals(false, resize(cumulative_gas_used_too_short), receipt);
-}
-
 #[test(should_fail_with="Cumulative gas used: Invalid RLP value)]
 fn test_assert_receipt_rlp_equals_invalid_cumulative_gas_used_value() {
     let mut receipt = receipt;
     receipt.cumulative_gas_used = wrapping_add(receipt.cumulative_gas_used, 1);
     assert_receipt_rlp_equals(false, receipt_rlp, receipt);
-}
-
-#[test(should_fail_with="Logs bloom: Invalid RLP type")]
-fn test_assert_receipt_rlp_equals_invalid_logs_bloom_type() {
-    let logs_bloom_is_a_list = [0xc7, 0x01, 0x83, 0x0a, 0x17, 0xe1, 0xc0, 0x80]; // ["0x01", "0x0a17e1", [], ""]
-    assert_receipt_rlp_equals(false, resize(logs_bloom_is_a_list), receipt);
-}
-
-#[test(should_fail_with="Logs bloom: Invalid RLP length")]
-fn test_assert_receipt_rlp_equals_invalid_logs_bloom_length() {
-    let logs_bloom_too_short = [0xc7, 0x01, 0x83, 0x0a, 0x17, 0xe1, 0x80, 0x80]; // ["0x01", "0x0a17e1", "", ""]
-    assert_receipt_rlp_equals(false, resize(logs_bloom_too_short), receipt);
 }
 
 #[test(should_fail_with="Logs bloom: Invalid RLP value")]


### PR DESCRIPTION
Remember we've had those 3 assertions per RLP field? This fixes that by introducing:
```rust
receipt_rlp_list.fragments[STATUS_INDEX].assert_string_eq(
            "Status",
            receipt_rlp,
            Into::into(([receipt.status.expect(f"Status is missing") as u8], 1 as u64))
        );
```

So RlpFragment now has a method on it to compare it to string value as [u8].

This allows us to have less tests in rlp decoding as we move those tests down and avoid N*M exlosion