### PR TITLE
subarray util method

### DIFF
--- a/ethereum_history_api/circuits/lib/src/misc/arrays.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays.nr
@@ -1,6 +1,6 @@
 use dep::std::{unsafe::zeroed, wrapping_add};
 
-pub fn alter_array<N>(array: [u8; N]) -> [u8; N] {
+pub fn alter_array<ARRAY_LEN>(array: [u8; ARRAY_LEN]) -> [u8; ARRAY_LEN] {
     let mut copy = array.map(|x| x);
     copy[0] = wrapping_add(copy[0], 1);
     copy
@@ -15,10 +15,10 @@ pub fn resize<TItem, NEW_LEN, OLD_LEN>(src: [TItem; OLD_LEN]) -> [TItem; NEW_LEN
     dest
 }
 
-pub(crate) fn memcpy_up_to_length<N, M>(dest: &mut [u8; N], src: [u8; M], offset: u64, length: u64) {
-    assert(length <= N, "Destination index out of bound");
-    assert(offset + length <= M, "Source index out of bound");
-    for i in 0..N {
+pub(crate) fn memcpy_up_to_length<TItem, SRC_LEN, DEST_LEN>(dest: &mut [TItem; DEST_LEN], src: [TItem; SRC_LEN], offset: u64, length: u64) {
+    assert(length <= DEST_LEN, "Destination index out of bound");
+    assert(offset + length <= SRC_LEN, "Source index out of bound");
+    for i in 0..DEST_LEN {
         if i < length {
             (*dest)[i] = src[offset + i];
         }
@@ -31,20 +31,26 @@ pub(crate) fn memcpy_up_to_length<N, M>(dest: &mut [u8; N], src: [u8; M], offset
 /// * `dest` - Destination array
 /// * `src` - Source array
 /// * `offset` - Offset in source array 
-pub(crate) fn memcpy<N, M>(dest: &mut [u8; N], src: [u8; M], offset: u64) {
-    memcpy_up_to_length(dest, src, offset, N);
+pub(crate) fn memcpy<TItem, SRC_LEN, DEST_LEN>(dest: &mut [TItem; DEST_LEN], src: [TItem; SRC_LEN], offset: u64) {
+    memcpy_up_to_length(dest, src, offset, DEST_LEN);
 }
 
-pub fn sub_array_equals_up_to_length<T, N, M>(
-    subarray: [T; N],
-    array: [T; M],
+pub fn subarray<TItem, SRC_LEN, DEST_LEN>(src: [TItem; SRC_LEN], offset: u64) -> [TItem; DEST_LEN] {
+    let mut dest = [zeroed(); DEST_LEN];
+    memcpy(&mut dest, src, offset);
+    dest
+}
+
+pub fn sub_array_equals_up_to_length<TItem, SUBARRAY_LEN, ARRAY_LEN>(
+    subarray: [TItem; SUBARRAY_LEN],
+    array: [TItem; ARRAY_LEN],
     offset: u64,
     length: u64
-) -> bool where T: Eq {
-    assert(length <= N, "subarray index out of bound");
-    assert(offset + N <= M, "array index out of bound");
+) -> bool where TItem: Eq {
+    assert(length <= SUBARRAY_LEN, "subarray index out of bound");
+    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "array index out of bound");
     let mut result = true;
-    for i in 0..N {
+    for i in 0..SUBARRAY_LEN {
         let loop_p = i < length;
         let equals_p = (subarray[i] == array[offset + i]);
         result &= !loop_p | equals_p;
@@ -52,15 +58,22 @@ pub fn sub_array_equals_up_to_length<T, N, M>(
     result
 }
 
-pub fn sub_array_equals<T, N, M>(subarray: [T; N], array: [T; M], offset: u64) -> bool where T: Eq {
-    assert(offset + N <= M, "array index out of bound");
+pub fn sub_array_equals<TItem, SUBARRAY_LEN, ARRAY_LEN>(
+    subarray: [TItem; SUBARRAY_LEN],
+    array: [TItem; ARRAY_LEN],
+    offset: u64
+) -> bool where TItem: Eq {
+    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "array index out of bound");
     let mut result = true;
-    for i in 0..N {
+    for i in 0..SUBARRAY_LEN {
         result &= subarray[i] == array[offset + i];
     }
     result
 }
 
-pub fn array_equals<T, N>(array1: [T; N], array2: [T; N]) -> bool where T: Eq {
+pub fn array_equals<TItem, ARRAY_LEN>(
+    array1: [TItem; ARRAY_LEN],
+    array2: [TItem; ARRAY_LEN]
+) -> bool where TItem: Eq {
     sub_array_equals(array1, array2, 0)
 }

--- a/ethereum_history_api/circuits/lib/src/misc/arrays.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays.nr
@@ -35,7 +35,7 @@ pub(crate) fn memcpy<TItem, SRC_LEN, DEST_LEN>(dest: &mut [TItem; DEST_LEN], src
     memcpy_up_to_length(dest, src, offset, DEST_LEN);
 }
 
-pub fn subarray<TItem, SRC_LEN, DEST_LEN>(src: [TItem; SRC_LEN], offset: u64) -> [TItem; DEST_LEN] {
+pub fn subarray_inferred_len<TItem, SRC_LEN, DEST_LEN>(src: [TItem; SRC_LEN], offset: u64) -> [TItem; DEST_LEN] {
     let mut dest = [zeroed(); DEST_LEN];
     memcpy(&mut dest, src, offset);
     dest

--- a/ethereum_history_api/circuits/lib/src/misc/arrays.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays.nr
@@ -47,8 +47,8 @@ pub fn sub_array_equals_up_to_length<TItem, SUBARRAY_LEN, ARRAY_LEN>(
     offset: u64,
     length: u64
 ) -> bool where TItem: Eq {
-    assert(length <= SUBARRAY_LEN, "subarray index out of bound");
-    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "array index out of bound");
+    assert(length <= SUBARRAY_LEN, "Subarray index out of bound");
+    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "Array index out of bound");
     let mut result = true;
     for i in 0..SUBARRAY_LEN {
         let loop_p = i < length;
@@ -63,7 +63,7 @@ pub fn sub_array_equals<TItem, SUBARRAY_LEN, ARRAY_LEN>(
     array: [TItem; ARRAY_LEN],
     offset: u64
 ) -> bool where TItem: Eq {
-    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "array index out of bound");
+    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "Array index out of bound");
     let mut result = true;
     for i in 0..SUBARRAY_LEN {
         result &= subarray[i] == array[offset + i];

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -67,7 +67,7 @@ mod sub_array_equals_up_to_length {
         assert(sub_array_equals_up_to_length(value, array, 1, 4), "Not equals");
     }
 
-    #[test(should_fail_with = "subarray index out of bound")]
+    #[test(should_fail_with = "Subarray index out of bound")]
     fn subarray_out_of_bound() {
         let value: [Field; 4] = [1, 2, 0, 0];
         let array: [Field; 6] = [42, 1, 2, 0, 0, 5];
@@ -94,7 +94,7 @@ mod sub_array_equals {
         assert(!sub_array_equals(sub_array, array, 2));
     }
 
-    #[test(should_fail_with = "array index out of bound")]
+    #[test(should_fail_with = "Array index out of bound")]
     fn index_out_of_bound() -> bool {
         let sub_array: [Field; 3] = [2, 3, 4];
         let array: [Field; 5] = [1, 2, 3, 4, 5];

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -152,27 +152,27 @@ mod resize {
     }
 }
 
-mod subarray {
-    use crate::misc::arrays::subarray;
+mod subarray_inferred_len {
+    use crate::misc::arrays::subarray_inferred_len;
 
     #[test]
     fn success() {
         let array = [1, 2, 3, 4, 5];
-        assert_eq(subarray(array, 0), array);
-        assert_eq(subarray(array, 1), []);
-        assert_eq(subarray(array, 1), [2]);
-        assert_eq(subarray(array, 1), [2, 3]);
-        assert_eq(subarray(array, 1), [2, 3, 4]);
-        assert_eq(subarray(array, 1), [2, 3, 4, 5]);
-        assert_eq(subarray(array, 4), []);
-        assert_eq(subarray(array, 4), [5]);
-        assert_eq(subarray(array, 5), []);
+        assert_eq(subarray_inferred_len(array, 0), array);
+        assert_eq(subarray_inferred_len(array, 1), []);
+        assert_eq(subarray_inferred_len(array, 1), [2]);
+        assert_eq(subarray_inferred_len(array, 1), [2, 3]);
+        assert_eq(subarray_inferred_len(array, 1), [2, 3, 4]);
+        assert_eq(subarray_inferred_len(array, 1), [2, 3, 4, 5]);
+        assert_eq(subarray_inferred_len(array, 4), []);
+        assert_eq(subarray_inferred_len(array, 4), [5]);
+        assert_eq(subarray_inferred_len(array, 5), []);
     }
 
     #[test]
     fn success_empty_src() {
         let array = [];
-        assert_eq(subarray(array, 0), []);
+        assert_eq(subarray_inferred_len(array, 0), []);
     }
 
     #[test]
@@ -181,13 +181,13 @@ mod subarray {
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
         ];
         assert_eq(
-            subarray(array, 12), [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+            subarray_inferred_len(array, 12), [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
         );
     }
 
     #[test(should_fail_with = "Source index out of bound")]
     fn source_index_out_of_bound() {
         let array = [1, 2, 3, 4, 5];
-        let _: [Field; 0] = subarray(array, 6);
+        let _: [Field; 0] = subarray_inferred_len(array, 6);
     }
 }

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -151,3 +151,43 @@ mod resize {
         let _ = array_equals(resize([1, 2]), [1]);
     }
 }
+
+mod subarray {
+    use crate::misc::arrays::subarray;
+
+    #[test]
+    fn success() {
+        let array = [1, 2, 3, 4, 5];
+        assert_eq(subarray(array, 0), array);
+        assert_eq(subarray(array, 1), []);
+        assert_eq(subarray(array, 1), [2]);
+        assert_eq(subarray(array, 1), [2, 3]);
+        assert_eq(subarray(array, 1), [2, 3, 4]);
+        assert_eq(subarray(array, 1), [2, 3, 4, 5]);
+        assert_eq(subarray(array, 4), []);
+        assert_eq(subarray(array, 4), [5]);
+        assert_eq(subarray(array, 5), []);
+    }
+
+    #[test]
+    fn success_empty_src() {
+        let array = [];
+        assert_eq(subarray(array, 0), []);
+    }
+
+    #[test]
+    fn success_convert_bytes32_to_bytes20() {
+        let array = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+        ];
+        assert_eq(
+            subarray(array, 12), [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+        );
+    }
+
+    #[test(should_fail_with = "Source index out of bound")]
+    fn source_index_out_of_bound() {
+        let array = [1, 2, 3, 4, 5];
+        let _: [Field; 0] = subarray(array, 6);
+    }
+}


### PR DESCRIPTION
I need this function to have a clean and simple API for NFT:
```rust
trait ERC721 {
    fn get_owner(self, token_id: Bytes32, block_number: Field) -> Address;
}
```
using `Fragments` it will look like 
```rust
fn get_owner(self, token_id: Bytes32, block_number: Field) -> Fragment<32>;
```
Under the hood we need to somehow convert `Bytes32` to `Address`