### PR TITLE
Remove unused logs-related generics from get_receipt

### DIFF
--- a/ethereum_history_api/circuits/get_receipt/src/main.nr
+++ b/ethereum_history_api/circuits/get_receipt/src/main.nr
@@ -1,12 +1,6 @@
 use dep::ethereum_history_api::receipt::{get_receipt, TxReceiptWithinBlock, PhantomReceiptProofLen, PhantomReceiptRlpLen};
 
-global LOG_NUM = 1;
-global MAX_LOG_DATA_LEN = 128;
-
-fn main(
-    block_number: pub Field,
-    tx_idx: pub Field
-) -> pub TxReceiptWithinBlock<LOG_NUM, MAX_LOG_DATA_LEN> {
+fn main(block_number: pub Field, tx_idx: pub Field) -> pub TxReceiptWithinBlock {
     let phantom_receipt_proof_len: PhantomReceiptProofLen <3724>  = PhantomReceiptProofLen {}; // = MAX_RECEIPT_TREE_DEPTH * MAX_TRIE_NODE_LENGTH
     let phantom_receipt_rlp_len: PhantomReceiptRlpLen <525>  = PhantomReceiptRlpLen {};
 

--- a/ethereum_history_api/circuits/lib/src/receipt.nr
+++ b/ethereum_history_api/circuits/lib/src/receipt.nr
@@ -19,14 +19,14 @@ type TxType = u8;
 struct PhantomReceiptProofLen<MAX_RECEIPT_PROOF_LEN> {}
 struct PhantomReceiptRlpLen<MAX_RECEIPT_ENCODED_LEN> {}
 
-struct TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN> {
+struct TxReceiptPartial {
     status: Option<u1>,
     state_root: Option<Bytes32>,
     cumulative_gas_used: u32,
     logs_bloom: [u8; BLOOM_FILTER_LEN]
 }
 
-struct ForeignCallTxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN> {
+struct ForeignCallTxReceiptPartial {
     status: u1,
     status_is_some: bool,
     state_root: Bytes32,
@@ -35,8 +35,8 @@ struct ForeignCallTxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN> {
     logs_bloom: [u8; BLOOM_FILTER_LEN]
 }
 
-struct TxReceiptWithinBlock<LOG_NUM, MAX_LOG_DATA_LEN> {
-    receipt: TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>,
+struct TxReceiptWithinBlock {
+    receipt: TxReceiptPartial,
     block_hash: Bytes32
 }
 
@@ -45,8 +45,8 @@ pub fn get_receipt<LOG_NUM, MAX_LOG_DATA_LEN, MAX_RECEIPT_PROOF_LEN, MAX_RECEIPT
     tx_idx: Field,
     _max_receipt_proof_len: PhantomReceiptProofLen<MAX_RECEIPT_PROOF_LEN>,
     _max_receipt_rlp_len: PhantomReceiptRlpLen<MAX_RECEIPT_ENCODED_LEN>
-) -> TxReceiptWithinBlock<LOG_NUM, MAX_LOG_DATA_LEN> {
-    let (tx_type, receipt, proof): (TxType, TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>, ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>) = get_receipt_unconstrained(block_number, tx_idx);
+) -> TxReceiptWithinBlock {
+    let (tx_type, receipt, proof): (TxType, TxReceiptPartial, ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>) = get_receipt_unconstrained(block_number, tx_idx);
     let header = get_header(block_number);
     verify_receipt(
         block_number,
@@ -63,12 +63,12 @@ pub fn get_receipt<LOG_NUM, MAX_LOG_DATA_LEN, MAX_RECEIPT_PROOF_LEN, MAX_RECEIPT
 unconstrained fn get_receipt_oracle<LOG_NUM, MAX_LOG_DATA_LEN, MAX_RECEIPT_PROOF_LEN, MAX_RECEIPT_ENCODED_LEN>(
     _block_number: Field,
     _tx_idx: Field
-) -> (TxType, ForeignCallTxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>, ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>) {}
+) -> (TxType, ForeignCallTxReceiptPartial, ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>) {}
 
 unconstrained fn get_receipt_unconstrained<LOG_NUM, MAX_LOG_DATA_LEN, MAX_RECEIPT_PROOF_LEN, MAX_RECEIPT_ENCODED_LEN>(
     block_number: Field,
     tx_idx: Field
-) -> (TxType, TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>, ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>) {
+) -> (TxType, TxReceiptPartial, ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>) {
     let (tx_type, receipt, proof) = get_receipt_oracle(block_number, tx_idx);
 
     let receipt = TxReceiptPartial {

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt.nr
@@ -17,11 +17,11 @@ pub(crate) fn is_pre_byzantium(block_number: u64) -> bool {
     block_number < BYZANTIUM_BLOCK_NUM as u64
 }
 
-pub(crate) fn assert_receipt_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
+pub(crate) fn assert_receipt_equals(
     block_number: Field,
     tx_type: TxType,
     encoded_receipt: [u8; MAX_ENCODED_RECEIPT_LENGTH],
-    receipt: TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>
+    receipt: TxReceiptPartial
 ) {
     let is_legacy = tx_type == 0;
     let (actual_tx_type, receipt_rlp) = split_into_tx_type_and_rlp(is_legacy, encoded_receipt);
@@ -42,7 +42,7 @@ pub fn verify_receipt<LOG_NUM, MAX_LOG_DATA_LEN, MAX_RECEIPT_PROOF_LEN>(
     block_number: Field,
     tx_idx: Field,
     tx_type: TxType,
-    receipt: TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>,
+    receipt: TxReceiptPartial,
     receipt_proof: ReceiptProof<MAX_RECEIPT_PROOF_LEN, MAX_ENCODED_RECEIPT_LENGTH>,
     receipt_root: [u8; HASH_LENGTH]
 ) {

--- a/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
+++ b/ethereum_history_api/circuits/lib/src/verifiers/receipt/rlp.nr
@@ -14,10 +14,10 @@ global STATUS_INDEX = 0;
 global CUMULATIVE_GAS_USED_INDEX = 1;
 global LOGS_BLOOM_INDEX = 2;
 
-pub(crate) fn assert_receipt_rlp_equals<LOG_NUM, MAX_LOG_DATA_LEN>(
+pub(crate) fn assert_receipt_rlp_equals(
     is_pre_byzantium: bool,
     receipt_rlp: [u8; MAX_RECEIPT_RLP_LENGTH],
-    receipt: TxReceiptPartial<LOG_NUM, MAX_LOG_DATA_LEN>
+    receipt: TxReceiptPartial
 ) {
     let receipt_rlp_list: RlpList<RECEIPT_FIELDS_COUNT> = decode_list(receipt_rlp);
     assert(receipt_rlp_list.num_fields == RECEIPT_FIELDS_COUNT, "Invalid number of fields in receipt RLP");


### PR DESCRIPTION
This is a leftover from times when we planned to return all logs as part of receipt
Now as we plan to have separate get_log function - this is redundant