### PR TITLE
Use enums to parse args in oracles

### DIFF
--- a/ethereum_history_api/oracles/src/noir/oracles/accountOracle.int.test.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/accountOracle.int.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getAccountOracle } from './accountOracle.js';
+import { OFFSETS, getAccountOracle } from './accountOracle.js';
 import { createMockClient } from '../../ethereum/mockClient.js';
 
 describe('accountOracle', () => {
-  const OFFSETS = {
-    NONCE: 0,
-    BALANCE: 1,
-    ADDRESS: 4,
-    DEPTH: 7
-  };
   it('getAccountOracle', async () => {
     // prettier-ignore
     const cryptoPunksAccountAddressInNoirFormat = [
@@ -27,7 +21,7 @@ describe('accountOracle', () => {
     ]);
     expect(account[OFFSETS.NONCE]).toStrictEqual('0x01');
     expect(account[OFFSETS.BALANCE]).toStrictEqual('0x0313570a84bf378efd25');
-    expect(account[OFFSETS.ADDRESS]).toStrictEqual(cryptoPunksAccountAddressInNoirFormat);
-    expect(account[OFFSETS.DEPTH]).toStrictEqual('0x08');
+    expect(account[OFFSETS.PROOF_KEY]).toStrictEqual(cryptoPunksAccountAddressInNoirFormat);
+    expect(account[OFFSETS.PROOF_DEPTH]).toStrictEqual('0x08');
   });
 });

--- a/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
@@ -5,13 +5,12 @@ import { encodeAccount, encodeStateProof } from './accountOracle/encode.js';
 import { decodeAddress, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { AlchemyClient } from '../../ethereum/client.js';
+import { Enum } from '../../util/enum.js';
 
 export enum ARGS {
   BLOCK_NUM,
-  ADDRESS,
-  _LENGTH
+  ADDRESS
 }
-const ARGS_COUNT: number = ARGS._LENGTH;
 
 export enum OFFSETS {
   NONCE,
@@ -40,7 +39,7 @@ export function decodeGetAccountArguments(args: NoirArguments): {
   blockNumber: bigint;
   address: Hex;
 } {
-  assert(args.length === ARGS_COUNT, `get_account requires ${ARGS_COUNT} arguments`);
+  assert(args.length === Enum.size(ARGS), `get_account requires ${Enum.size(ARGS)} arguments`);
 
   assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
   const blockNumber = decodeField(args[ARGS.BLOCK_NUM][0]);

--- a/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
@@ -5,13 +5,13 @@ import { encodeAccount, encodeStateProof } from './accountOracle/encode.js';
 import { decodeAddress, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { AlchemyClient } from '../../ethereum/client.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM,
   ADDRESS
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
 
 export enum OFFSETS {
   NONCE,

--- a/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
@@ -5,10 +5,24 @@ import { encodeAccount, encodeStateProof } from './accountOracle/encode.js';
 import { decodeAddress, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { AlchemyClient } from '../../ethereum/client.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
 
-const GET_ACCOUNT_ARGS_COUNT = 2;
-const BLOCK_NUM_INDEX = 0;
-const ADDRESS_INDEX = 1;
+export enum ARGS {
+  BLOCK_NUM,
+  ADDRESS
+}
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
+
+export enum OFFSETS {
+  NONCE,
+  BALANCE,
+  STORAGE_ROOT,
+  CODE_HASH,
+  PROOF_KEY,
+  PROOF_VALUE,
+  PROOF,
+  PROOF_DEPTH
+}
 
 export async function getAccountOracle(client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> {
   const { blockNumber, address } = decodeGetAccountArguments(args);
@@ -26,11 +40,11 @@ export function decodeGetAccountArguments(args: NoirArguments): {
   blockNumber: bigint;
   address: Hex;
 } {
-  assert(args.length === GET_ACCOUNT_ARGS_COUNT, 'get_account requires 2 arguments');
+  assert(args.length === ARGS_COUNT, `get_account requires ${ARGS_COUNT} arguments`);
 
-  assert(args[BLOCK_NUM_INDEX].length === 1, 'blockNumber should be a single value');
-  const blockNumber = decodeField(args[BLOCK_NUM_INDEX][0]);
-  const address = decodeAddress(args[ADDRESS_INDEX]);
+  assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
+  const blockNumber = decodeField(args[ARGS.BLOCK_NUM][0]);
+  const address = decodeAddress(args[ARGS.ADDRESS]);
 
   return { blockNumber, address };
 }

--- a/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/accountOracle.ts
@@ -5,13 +5,13 @@ import { encodeAccount, encodeStateProof } from './accountOracle/encode.js';
 import { decodeAddress, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { AlchemyClient } from '../../ethereum/client.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM,
-  ADDRESS
+  ADDRESS,
+  _LENGTH
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
+const ARGS_COUNT: number = ARGS._LENGTH;
 
 export enum OFFSETS {
   NONCE,

--- a/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
@@ -6,12 +6,11 @@ import { decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { type Block } from '../../ethereum/blockHeader.js';
 import { AlchemyClient } from '../../ethereum/client.js';
+import { Enum } from '../../util/enum.js';
 
 export enum ARGS {
-  BLOCK_NUM,
-  _LENGTH
+  BLOCK_NUM
 }
-const ARGS_COUNT: number = ARGS._LENGTH;
 
 export async function getHeaderOracle(client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> {
   const blockNumber: bigint = decodeGetHeaderArguments(args);
@@ -20,7 +19,7 @@ export async function getHeaderOracle(client: AlchemyClient, args: NoirArguments
 }
 
 export function decodeGetHeaderArguments(args: NoirArguments): bigint {
-  assert(args.length === ARGS_COUNT, `get_header requires ${ARGS_COUNT} argument`);
+  assert(args.length === Enum.size(ARGS), `get_header requires ${Enum.size(ARGS)} argument`);
   assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
   return decodeField(args[ARGS.BLOCK_NUM][0]);
 }

--- a/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
@@ -6,12 +6,12 @@ import { decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { type Block } from '../../ethereum/blockHeader.js';
 import { AlchemyClient } from '../../ethereum/client.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
 
 export async function getHeaderOracle(client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> {
   const blockNumber: bigint = decodeGetHeaderArguments(args);

--- a/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
@@ -6,8 +6,12 @@ import { decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { type Block } from '../../ethereum/blockHeader.js';
 import { AlchemyClient } from '../../ethereum/client.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
 
-const GET_HEADER_ARGS_COUNT = 1;
+export enum ARGS {
+  BLOCK_NUM
+}
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
 
 export async function getHeaderOracle(client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> {
   const blockNumber: bigint = decodeGetHeaderArguments(args);
@@ -16,9 +20,9 @@ export async function getHeaderOracle(client: AlchemyClient, args: NoirArguments
 }
 
 export function decodeGetHeaderArguments(args: NoirArguments): bigint {
-  assert(args.length === GET_HEADER_ARGS_COUNT, 'get_header requires 1 argument');
-  assert(args[0].length === 1, 'blockNumber should be a single value');
-  return decodeField(args[0][0]);
+  assert(args.length === ARGS_COUNT, `get_header requires ${ARGS_COUNT} argument`);
+  assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
+  return decodeField(args[ARGS.BLOCK_NUM][0]);
 }
 
 export async function getBlockHeader(client: AlchemyClient, blockNumber: bigint): Promise<BlockHeader> {

--- a/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/headerOracle.ts
@@ -6,12 +6,12 @@ import { decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { type Block } from '../../ethereum/blockHeader.js';
 import { AlchemyClient } from '../../ethereum/client.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
-  BLOCK_NUM
+  BLOCK_NUM,
+  _LENGTH
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
+const ARGS_COUNT: number = ARGS._LENGTH;
 
 export async function getHeaderOracle(client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> {
   const blockNumber: bigint = decodeGetHeaderArguments(args);

--- a/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
@@ -5,14 +5,14 @@ import { decodeAddress, decodeBytes32, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { Hex } from 'viem';
 import { AlchemyClient } from '../../ethereum/client.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM,
   ADDRESS,
-  STORAGE_KEY
+  STORAGE_KEY,
+  _LENGTH
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
+const ARGS_COUNT: number = ARGS._LENGTH;
 
 export const getProofOracle = async (client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> => {
   const { blockNumber, address, storageKey } = decodeGetProofArguments(args);

--- a/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
@@ -5,14 +5,14 @@ import { decodeAddress, decodeBytes32, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { Hex } from 'viem';
 import { AlchemyClient } from '../../ethereum/client.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM,
   ADDRESS,
   STORAGE_KEY
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
 
 export const getProofOracle = async (client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> => {
   const { blockNumber, address, storageKey } = decodeGetProofArguments(args);

--- a/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
@@ -5,14 +5,13 @@ import { decodeAddress, decodeBytes32, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { Hex } from 'viem';
 import { AlchemyClient } from '../../ethereum/client.js';
+import { Enum } from '../../util/enum.js';
 
 export enum ARGS {
   BLOCK_NUM,
   ADDRESS,
-  STORAGE_KEY,
-  _LENGTH
+  STORAGE_KEY
 }
-const ARGS_COUNT: number = ARGS._LENGTH;
 
 export const getProofOracle = async (client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> => {
   const { blockNumber, address, storageKey } = decodeGetProofArguments(args);
@@ -32,7 +31,7 @@ export function decodeGetProofArguments(args: NoirArguments): {
   address: Hex;
   storageKey: Hex;
 } {
-  assert(args.length === ARGS_COUNT, `get_proof requires ${ARGS_COUNT} arguments`);
+  assert(args.length === Enum.size(ARGS), `get_proof requires ${Enum.size(ARGS)} arguments`);
 
   assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
   const blockNumber = decodeField(args[ARGS.BLOCK_NUM][0]);

--- a/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/proofOracle.ts
@@ -5,11 +5,14 @@ import { decodeAddress, decodeBytes32, decodeField } from './common/decode.js';
 import { NoirArguments } from './oracles.js';
 import { Hex } from 'viem';
 import { AlchemyClient } from '../../ethereum/client.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
 
-const GET_PROOF_ARGS_COUNT = 3;
-const BLOCK_NUM_INDEX = 0;
-const ADDRESS_INDEX = 1;
-const STORAGE_KEY_INDEX = 2;
+export enum ARGS {
+  BLOCK_NUM,
+  ADDRESS,
+  STORAGE_KEY
+}
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
 
 export const getProofOracle = async (client: AlchemyClient, args: NoirArguments): Promise<ForeignCallOutput[]> => {
   const { blockNumber, address, storageKey } = decodeGetProofArguments(args);
@@ -29,12 +32,12 @@ export function decodeGetProofArguments(args: NoirArguments): {
   address: Hex;
   storageKey: Hex;
 } {
-  assert(args.length === GET_PROOF_ARGS_COUNT, `get_proof requires ${GET_PROOF_ARGS_COUNT} arguments`);
+  assert(args.length === ARGS_COUNT, `get_proof requires ${ARGS_COUNT} arguments`);
 
-  assert(args[BLOCK_NUM_INDEX].length === 1, 'blockNumber should be a single value');
-  const blockNumber = decodeField(args[BLOCK_NUM_INDEX][0]);
-  const address = decodeAddress(args[ADDRESS_INDEX]);
-  const storageKey = decodeBytes32(args[STORAGE_KEY_INDEX]);
+  assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
+  const blockNumber = decodeField(args[ARGS.BLOCK_NUM][0]);
+  const address = decodeAddress(args[ARGS.ADDRESS]);
+  const storageKey = decodeBytes32(args[ARGS.STORAGE_KEY]);
 
   return { blockNumber, address, storageKey };
 }

--- a/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
@@ -6,10 +6,13 @@ import { AlchemyClient } from '../../ethereum/client.js';
 import { getReceiptProof } from '../../ethereum/receiptProof.js';
 import { encodeReceipt, encodeReceiptProof } from './receiptOracle/encode.js';
 import { txTypeToHex } from '../../ethereum/receipt.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
 
-const GET_RECEIPT_ARGS_COUNT = 2;
-const BLOCK_NUM_INDEX = 0;
-const TX_ID_INDEX = 1;
+export enum ARGS {
+  BLOCK_NUM,
+  TX_ID
+}
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
 
 export enum OFFSETS {
   TX_TYPE,
@@ -47,11 +50,11 @@ export function decodeGetReceiptArguments(args: NoirArguments): {
   blockNumber: bigint;
   txId: number;
 } {
-  assert(args.length === GET_RECEIPT_ARGS_COUNT, `get_receipt requires ${GET_RECEIPT_ARGS_COUNT} arguments`);
+  assert(args.length === ARGS_COUNT, `get_receipt requires ${ARGS_COUNT} arguments`);
 
-  assert(args[BLOCK_NUM_INDEX].length === 1, 'blockNumber should be a single value');
-  const blockNumber = decodeField(args[BLOCK_NUM_INDEX][0]);
-  const txId = Number(decodeField(args[TX_ID_INDEX][0]));
+  assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
+  const blockNumber = decodeField(args[ARGS.BLOCK_NUM][0]);
+  const txId = Number(decodeField(args[ARGS.TX_ID][0]));
 
   return { blockNumber, txId };
 }

--- a/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
@@ -6,13 +6,13 @@ import { AlchemyClient } from '../../ethereum/client.js';
 import { getReceiptProof } from '../../ethereum/receiptProof.js';
 import { encodeReceipt, encodeReceiptProof } from './receiptOracle/encode.js';
 import { txTypeToHex } from '../../ethereum/receipt.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATO } from '../../util/const.js';
+import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM,
   TX_ID
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATO;
+const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
 
 export enum OFFSETS {
   TX_TYPE,

--- a/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
@@ -6,13 +6,12 @@ import { AlchemyClient } from '../../ethereum/client.js';
 import { getReceiptProof } from '../../ethereum/receiptProof.js';
 import { encodeReceipt, encodeReceiptProof } from './receiptOracle/encode.js';
 import { txTypeToHex } from '../../ethereum/receipt.js';
+import { Enum } from '../../util/enum.js';
 
 export enum ARGS {
   BLOCK_NUM,
-  TX_ID,
-  _LENGTH
+  TX_ID
 }
-const ARGS_COUNT: number = ARGS._LENGTH;
 
 export enum OFFSETS {
   TX_TYPE,
@@ -50,7 +49,7 @@ export function decodeGetReceiptArguments(args: NoirArguments): {
   blockNumber: bigint;
   txId: number;
 } {
-  assert(args.length === ARGS_COUNT, `get_receipt requires ${ARGS_COUNT} arguments`);
+  assert(args.length === Enum.size(ARGS), `get_receipt requires ${Enum.size(ARGS)} arguments`);
 
   assert(args[ARGS.BLOCK_NUM].length === 1, 'blockNumber should be a single value');
   const blockNumber = decodeField(args[ARGS.BLOCK_NUM][0]);

--- a/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
+++ b/ethereum_history_api/oracles/src/noir/oracles/receiptOracle.ts
@@ -6,13 +6,13 @@ import { AlchemyClient } from '../../ethereum/client.js';
 import { getReceiptProof } from '../../ethereum/receiptProof.js';
 import { encodeReceipt, encodeReceiptProof } from './receiptOracle/encode.js';
 import { txTypeToHex } from '../../ethereum/receipt.js';
-import { ENUM_LEN_TO_ENUM_KEY_LEN_RATIO } from '../../util/const.js';
 
 export enum ARGS {
   BLOCK_NUM,
-  TX_ID
+  TX_ID,
+  _LENGTH
 }
-const ARGS_COUNT = Object.keys(ARGS).length / ENUM_LEN_TO_ENUM_KEY_LEN_RATIO;
+const ARGS_COUNT: number = ARGS._LENGTH;
 
 export enum OFFSETS {
   TX_TYPE,

--- a/ethereum_history_api/oracles/src/util/const.ts
+++ b/ethereum_history_api/oracles/src/util/const.ts
@@ -1,4 +1,4 @@
 export const BYTE_HEX_LEN = 2;
 export const U1_ZERO = '0x00';
 export const BYTES_32_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
-export const ENUM_LEN_TO_ENUM_KEY_LEN_RATO = 2; // TS enums contain reverse mapping too: https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings
+export const ENUM_LEN_TO_ENUM_KEY_LEN_RATIO = 2; // TS enums contain reverse mapping too: https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings

--- a/ethereum_history_api/oracles/src/util/const.ts
+++ b/ethereum_history_api/oracles/src/util/const.ts
@@ -1,4 +1,3 @@
 export const BYTE_HEX_LEN = 2;
 export const U1_ZERO = '0x00';
 export const BYTES_32_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
-export const ENUM_LEN_TO_ENUM_KEY_LEN_RATIO = 2; // TS numeric enums contain reverse mapping: https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings

--- a/ethereum_history_api/oracles/src/util/const.ts
+++ b/ethereum_history_api/oracles/src/util/const.ts
@@ -1,3 +1,4 @@
 export const BYTE_HEX_LEN = 2;
 export const U1_ZERO = '0x00';
 export const BYTES_32_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
+export const ENUM_LEN_TO_ENUM_KEY_LEN_RATO = 2; // TS enums contain reverse mapping too: https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings

--- a/ethereum_history_api/oracles/src/util/const.ts
+++ b/ethereum_history_api/oracles/src/util/const.ts
@@ -1,4 +1,4 @@
 export const BYTE_HEX_LEN = 2;
 export const U1_ZERO = '0x00';
 export const BYTES_32_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
-export const ENUM_LEN_TO_ENUM_KEY_LEN_RATIO = 2; // TS enums contain reverse mapping too: https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings
+export const ENUM_LEN_TO_ENUM_KEY_LEN_RATIO = 2; // TS numeric enums contain reverse mapping: https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings

--- a/ethereum_history_api/oracles/src/util/enum.ts
+++ b/ethereum_history_api/oracles/src/util/enum.ts
@@ -1,0 +1,6 @@
+export class Enum {
+  public static size<T extends object>(enumObj: T): number {
+    const keys = Object.keys(enumObj).filter((key) => isNaN(Number(key)));
+    return keys.length;
+  }
+}


### PR DESCRIPTION
This approach is better as the indexes and sizes are computed automatically. One less thing to worry about