### PR TITLE
Small fix in sub_array_equals_up_to_length

### DIFF
--- a/ethereum_history_api/circuits/lib/src/misc/arrays.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays.nr
@@ -48,12 +48,11 @@ pub fn sub_array_equals_up_to_length<TItem, SUBARRAY_LEN, ARRAY_LEN>(
     length: u64
 ) -> bool where TItem: Eq {
     assert(length <= SUBARRAY_LEN, "Subarray index out of bound");
-    assert(offset + SUBARRAY_LEN <= ARRAY_LEN, "Array index out of bound");
     let mut result = true;
     for i in 0..SUBARRAY_LEN {
-        let loop_p = i < length;
-        let equals_p = (subarray[i] == array[offset + i]);
-        result &= !loop_p | equals_p;
+        if i < length {
+            result &= subarray[i] == array[offset + i];
+        }
     }
     result
 }

--- a/ethereum_history_api/circuits/lib/src/misc/arrays.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays.nr
@@ -48,6 +48,7 @@ pub fn sub_array_equals_up_to_length<TItem, SUBARRAY_LEN, ARRAY_LEN>(
     length: u64
 ) -> bool where TItem: Eq {
     assert(length <= SUBARRAY_LEN, "Subarray index out of bound");
+    assert(offset + length <= ARRAY_LEN, "Array index out of bound");
     let mut result = true;
     for i in 0..SUBARRAY_LEN {
         if i < length {

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -62,9 +62,20 @@ mod sub_array_equals_up_to_length {
 
     #[test]
     fn success_big_subarray() {
-        let value: [Field; 4] = [1, 2, 0, 0];
+        let subarray: [Field; 4] = [1, 2, 0, 0];
         let array: [Field; 5] = [0, 0, 1, 2, 0];
-        assert(sub_array_equals_up_to_length(value, array, 2, 3));
+        assert(sub_array_equals_up_to_length(subarray, array, 2, 3));
+    }
+
+    #[test]
+    fn success_big() {
+        let subarray: [Field; 90] = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+        ];
+        let array: [Field; 100] = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+        ];
+        assert(sub_array_equals_up_to_length(subarray, array, 20, 80));
     }
 
     #[test(should_fail_with = "Not equals")]

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -80,6 +80,13 @@ mod sub_array_equals_up_to_length {
         let array: [Field; 6] = [42, 1, 2, 0, 0, 5];
         assert(sub_array_equals_up_to_length(value, array, 1, 5));
     }
+
+    #[test(should_fail)] // Unfortunately in-loop index access happens before the assert
+    fn array_out_of_bound() {
+        let value: [Field; 5] = [1, 2, 0, 0, 5];
+        let array: [Field; 5] = [42, 1, 2, 0, 0];
+        assert(sub_array_equals_up_to_length(value, array, 1, 5));
+    }
 }
 
 mod sub_array_equals {

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -60,6 +60,13 @@ mod sub_array_equals_up_to_length {
         assert(sub_array_equals_up_to_length(value, array, 1, 4));
     }
 
+     #[test]
+    fn success_big_subarray() {
+        let value: [Field; 4] = [1, 2, 0, 0];
+        let array: [Field; 5] = [0, 0, 1, 2, 0];
+        assert(sub_array_equals_up_to_length(value, array, 2, 3));
+    }
+
     #[test(should_fail_with = "Not equals")]
     fn full_length_not_equals() {
         let value: [Field; 4] = [1, 2, 0, 0];
@@ -72,13 +79,6 @@ mod sub_array_equals_up_to_length {
         let value: [Field; 4] = [1, 2, 0, 0];
         let array: [Field; 6] = [42, 1, 2, 0, 0, 5];
         assert(sub_array_equals_up_to_length(value, array, 1, 5));
-    }
-
-    #[test(should_fail)] // Unfortunately in-loop index access happens before the assert
-    fn array_out_of_bound() {
-        let value: [Field; 4] = [1, 2, 0, 0];
-        let array: [Field; 5] = [0, 0, 1, 2, 0];
-        assert(sub_array_equals_up_to_length(value, array, 2, 3));
     }
 }
 

--- a/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
+++ b/ethereum_history_api/circuits/lib/src/misc/arrays_test.nr
@@ -60,7 +60,7 @@ mod sub_array_equals_up_to_length {
         assert(sub_array_equals_up_to_length(value, array, 1, 4));
     }
 
-     #[test]
+    #[test]
     fn success_big_subarray() {
         let value: [Field; 4] = [1, 2, 0, 0];
         let array: [Field; 5] = [0, 0, 1, 2, 0];


### PR DESCRIPTION
_sub_array_equals_up_to_length(subarray, array, offset, length)_ previously enforced that length of array is larger than length of subarray shifted by the offset (offset + SUB_ARRAY_LEN < ARRAY_LEN)
It doesn't make sense though to enforce it because we only want to check if arrays are equal up to specified length, not up to length of the whole subarray.

Instead it should enforce that offset + length < ARRAY_LEN