### PR TITLE
Extend revert error name to be more specific

### DIFF
--- a/ethereum_history_api/contracts/src/EthereumHistoryVerifier.sol
+++ b/ethereum_history_api/contracts/src/EthereumHistoryVerifier.sol
@@ -2,17 +2,19 @@
 pragma solidity ^0.8.13;
 
 error InvalidBlockHash(uint256 blockNo, bytes32 blockHash);
-error InvalidBlockNumber(uint256 blockNo);
+error BlockTooOld(uint256 blockNo);
+error BlockInTheFuture(uint256 blockNo);
 
 contract EthereumHistoryVerifier {
-
-    function verify(uint blockNo, bytes32 blockHash) view public {
+    function verify(uint blockNo, bytes32 blockHash) public view {
+        if (blockNo >= block.number) {
+            revert BlockInTheFuture(blockNo);
+        }
         if (blockhash(blockNo) != blockHash) {
             revert InvalidBlockHash(blockNo, blockHash);
         }
         if (blockhash(blockNo) == bytes32(0)) {
-            revert InvalidBlockNumber(blockNo);
+            revert BlockTooOld(blockNo);
         }
     }
-
 }

--- a/ethereum_history_api/contracts/test/EthereumHistoryVerifier.t.sol
+++ b/ethereum_history_api/contracts/test/EthereumHistoryVerifier.t.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, console2} from "forge-std/Test.sol";
-import {EthereumHistoryVerifier, InvalidBlockHash, InvalidBlockNumber} from "../src/EthereumHistoryVerifier.sol";
-
+import {Test, console2} from 'forge-std/Test.sol';
+import {EthereumHistoryVerifier, InvalidBlockHash, BlockTooOld, BlockInTheFuture} from '../src/EthereumHistoryVerifier.sol';
 
 contract EthereumHistoryVerifierTest is Test {
     EthereumHistoryVerifier public verifier;
@@ -14,14 +13,14 @@ contract EthereumHistoryVerifierTest is Test {
     }
 
     function test_correct_block() public view {
-        uint blockNo = block.number-1;
+        uint blockNo = block.number - 1;
         bytes32 blockHash = blockhash(blockNo);
         verifier.verify(blockNo, blockHash);
     }
 
     function test_RevertWhenInvalidHash() public {
-        uint blockNo = block.number-1;
-        bytes32 blockHash = blockhash(blockNo-1);
+        uint blockNo = block.number - 1;
+        bytes32 blockHash = blockhash(blockNo - 1);
 
         vm.expectRevert(abi.encodeWithSelector(InvalidBlockHash.selector, blockNo, blockHash));
         verifier.verify(blockNo, blockHash);
@@ -31,7 +30,7 @@ contract EthereumHistoryVerifierTest is Test {
         uint blockNo = block.number;
         bytes32 blockHash = blockhash(blockNo);
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidBlockNumber.selector, blockNo));
+        vm.expectRevert(abi.encodeWithSelector(BlockInTheFuture.selector, blockNo));
         verifier.verify(blockNo, blockHash);
     }
 
@@ -39,7 +38,7 @@ contract EthereumHistoryVerifierTest is Test {
         uint blockNo = block.number + 1;
         bytes32 blockHash = blockhash(blockNo);
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidBlockNumber.selector, blockNo));
+        vm.expectRevert(abi.encodeWithSelector(BlockInTheFuture.selector, blockNo));
         verifier.verify(blockNo, blockHash);
     }
 
@@ -47,7 +46,7 @@ contract EthereumHistoryVerifierTest is Test {
         uint blockNo = block.number - 257;
         bytes32 blockHash = blockhash(blockNo);
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidBlockNumber.selector, blockNo));
+        vm.expectRevert(abi.encodeWithSelector(BlockTooOld.selector, blockNo));
         verifier.verify(blockNo, blockHash);
     }
 


### PR DESCRIPTION
`InvalidBlockNumber` might be misleading for a caller. 
I suggested `InvalidOrOldBlockNumber` so caller may get the clue that block number might be valid, but just too old to be used. 