### PR TITLE
Update README to include transactions & new monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,8 @@
-# noir-ethereum-history-api
+# vLayer monorepo
 
-**noir-ethereum-history-api** is a [Noir](https://noir-lang.org) library for proving and verifying historical data on the Ethereum blockchain and other EVM compatible blockchains.
-
-It allows you to prove:
-
-- Account state
-  - `balance`, `nonce`, `codeHash`, `storageRoot`
-  - Example: _`Vitalik's` balance was `5 ETH` at block `N`_
-- Storage values by key
-  - Example: _`Uniswap` contract had value `5` at storage slot `0` at block `N`_
-- Transaction inclusion
-  - Example: _Transaction number `115` in block `N` was sending `3 ETH` to address `to`_
-- Receipt inclusion
-  - Example: _Transaction number `115` in block `N` succeeded (`status == 1`) and used `100k` gas_
-- Log inclusion
-  - Example: _Log number `0` within transaction number `115` in block `N` has `topic0 === 0x...`_
-
-Additionally, we provide [smart contracts](./ethereum_history_api/contracts/src/EthereumHistoryVerifier.sol) that allow to verify inclusion of block in the chain for last 256 blocks.
-
-## Repository structure
-
-This monorepo consists of the following sub-projects:
-
-| Package                                          | Description                                                                     | Docs                                                |
-| ------------------------------------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [`Circuits`](ethereum_history_api/circuits/lib/) | Noir circuits to generate account and storage proofs for historical blocks data | [Docs](ethereum_history_api/circuits/lib/README.md) |
-| [`Contracts`](ethereum_history_api/contracts/)   | Related Solidity contracts with tests                                           | [Docs](ethereum_history_api/contracts/README.md)    |
-| [`Oracles`](ethereum_history_api/oracles/)       | TypeScript oracle server that provides data for circuits                        | [Docs](ethereum_history_api/oracles/README.md)      |
-| [`Tests`](ethereum_history_api/tests/)           | E2E tests in TypeScript                                                         | [Docs](ethereum_history_api/tests/README.md)        |
+This monorepo contains two sub-projects:
+* **noir-ethereum-history-api** - [Noir](https://noir-lang.org) library for proving and verifying historical data on the Ethereum blockchain and other EVM compatible blockchains. It supports proving accounts, storage, logs, receipts & transactions. Checkout it's **[docs](./ethereum_history_api/README.md)** for more details.
+* **vLayer** - Contains examples of what can be achieved using **noir-ethereum-history-api**. It's a work in progress and lacks documentation.
 
 ## Prerequisites
 
@@ -53,20 +28,11 @@ yarn check
 
 To run checks individually use:
 
-`yarn lint:all` - to run `eslint` on the whole repo
+* `yarn lint:all` - to run `eslint` on the whole repo
 
-`yarn format:all` - to run `prettier` on the whole repo
+* `yarn format:all` - to run `prettier` on the whole repo
 
-`yarn typecheck:all` - to run `typescript` checks on the whole repo
-
-### Compilation & testing
-
-Compilation and testing instructions for individual projects:
-
-- [Circuits](ethereum_history_api/circuits/lib/README.md#compilation)
-- [Contracts](ethereum_history_api/contracts/README.md#build)
-- [Oracles](ethereum_history_api/oracles/README.md#testing)
-- [Tests](ethereum_history_api/tests/README.md#running-e2e-tests)
+* `yarn typecheck:all` - to run `typescript` checks on the whole repo
 
 ### CI workflows
 
@@ -74,4 +40,4 @@ We use Github actions to run tests on CI. For a detailed description of what doe
 
 ## DISCLAIMER
 
-This library is in active development and subject to breaking changes. Use at your own risk. No responsibility is assumed for any potential issues arising from its use.
+The code in this repo is in active development and subject to breaking changes. Use at your own risk. No responsibility is assumed for any potential issues arising from its use.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This monorepo contains two sub-projects:
 * **noir-ethereum-history-api** - [Noir](https://noir-lang.org) library for proving and verifying historical data on the Ethereum blockchain and other EVM compatible blockchains. It supports proving accounts, storage, logs, receipts & transactions. Checkout it's **[docs](./ethereum_history_api/README.md)** for more details.
-* **vLayer** - Contains examples of what can be achieved using **noir-ethereum-history-api**. It's a work in progress and lacks documentation.
+* **vLayer** - Contains real life examples of what can be achieved using **noir-ethereum-history-api**. It's a work in progress and lacks documentation.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # vLayer monorepo
 
 This monorepo contains two sub-projects:
-* **noir-ethereum-history-api** - [Noir](https://noir-lang.org) library for proving and verifying historical data on the Ethereum blockchain and other EVM compatible blockchains. It supports proving accounts, storage, logs, receipts & transactions. Checkout it's **[docs](./ethereum_history_api/README.md)** for more details.
-* **vLayer** - Contains real life examples of what can be achieved using **noir-ethereum-history-api**. It's a work in progress and lacks documentation.
+
+- **noir-ethereum-history-api** - [Noir](https://noir-lang.org) library for proving and verifying historical data on the Ethereum blockchain and other EVM compatible blockchains. It supports proving accounts, storage, logs, receipts & transactions. Checkout it's **[docs](./ethereum_history_api/README.md)** for more details.
+- **vLayer** - Contains real life examples of what can be built using **noir-ethereum-history-api**. It's a work in progress and lacks documentation.
 
 ## Prerequisites
 
@@ -28,11 +29,11 @@ yarn check
 
 To run checks individually use:
 
-* `yarn lint:all` - to run `eslint` on the whole repo
+- `yarn lint:all` - to run `eslint` on the whole repo
 
-* `yarn format:all` - to run `prettier` on the whole repo
+- `yarn format:all` - to run `prettier` on the whole repo
 
-* `yarn typecheck:all` - to run `typescript` checks on the whole repo
+- `yarn typecheck:all` - to run `typescript` checks on the whole repo
 
 ### CI workflows
 

--- a/ethereum_history_api/README.md
+++ b/ethereum_history_api/README.md
@@ -1,0 +1,37 @@
+# noir-ethereum-history-api
+
+This project contains a library that allows you to prove:
+
+- Account state
+  - `balance`, `nonce`, `codeHash`, `storageRoot`
+  - Example: _`Vitalik's` balance was `5 ETH` at block `N`_
+- Storage values by key
+  - Example: _`Uniswap` contract had value `5` at storage slot `0` at block `N`_
+- Transaction inclusion
+  - Example: _Transaction number `115` in block `N` was sending `3 ETH` to address `to`_
+- Receipt inclusion
+  - Example: _Transaction number `115` in block `N` succeeded (`status == 1`) and used `100k` gas_
+- Log inclusion
+  - Example: _Log number `0` within transaction number `115` in block `N` has `topic0 === 0x...`_
+
+Additionally, we provide [smart contracts](./ethereum_history_api/contracts/src/EthereumHistoryVerifier.sol) that allow to verify inclusion of block in the chain for last 256 blocks.
+
+## Repository structure
+
+This monorepo consists of the following sub-projects:
+
+| Package                                          | Description                                                                     | Docs                                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------- |
+| [`Circuits`](./circuits/lib/) | Noir circuits to generate account and storage proofs for historical blocks data | [Docs](./circuits/lib/README.md) |
+| [`Contracts`](./contracts/)   | Related Solidity contracts with tests                                           | [Docs](./contracts/README.md)    |
+| [`Oracles`](./oracles/)       | TypeScript oracle server that provides data for circuits                        | [Docs](./oracles/README.md)      |
+| [`Tests`](./tests/)           | E2E tests in TypeScript                                                         | [Docs](./tests/README.md)        |
+
+### Compilation & testing
+
+Compilation and testing instructions for individual projects:
+
+- [Circuits](./circuits/lib/README.md#compilation)
+- [Contracts](./contracts/README.md#build)
+- [Oracles](./oracles/README.md#testing)
+- [Tests](./tests/README.md#running-e2e-tests)

--- a/ethereum_history_api/circuits/README.md
+++ b/ethereum_history_api/circuits/README.md
@@ -11,6 +11,7 @@ Noir circuits for proving and verifying historical data on the Ethereum blockcha
 | [`get_account`](./get_header/)  | Binary crate for generating account proofs  | [Docs](./get_account/README.md) |
 | [`get_storage`](./get_storage/) | Binary crate for generating storage proofs  | [Docs](./get_storage/README.md) |
 | [`get_receipt`](./get_receipt/) | Binary crate for generating receipt proofs  | [Docs](./get_receipt/README.md) |
+| [`get_transaction`](./get_transaction/) | Binary crate for generating transaction proofs  | [Docs](./get_transaction/README.md) |
 
 ## Compile
 

--- a/ethereum_history_api/circuits/lib/README.md
+++ b/ethereum_history_api/circuits/lib/README.md
@@ -5,6 +5,7 @@ Noir library for proving and verifying historical data on the Ethereum blockchai
 **Disclaimer:** This page is supposed to give you an idea about the usage and structure of the library, but it's still a good idea to consult the code for exact definitions of functions & types.
 
 **Note:** This library also contains two sublibraries: _rlp_ for RLP-decoding and _merkle_patricia_proofs_ for verifying merkle patricia proofs. To learn more about them follow the links below:
+
 - [rlp](./src/rlp/README.md)
 - [merkle_patricia_proofs](./src/merkle_patricia_proofs/README.md)
 
@@ -23,19 +24,28 @@ If you decide to use our Oracles - you don't need to provide all the data by han
 Here is a list of public functions that you should use if you decide to go the **oracles route**:
 
 ```rust
-pub fn get_header(chain_id: Field, block_number: Field) -> BlockHeaderPartial;
+pub fn get_header(chain_id: Field, block_number: u64) -> BlockHeaderPartial;
 ```
 
 ```rust
-pub fn get_account(chain_id: Field, block_no: Field, address: Address) -> AccountWithinBlock;
+pub fn get_account(chain_id: Field, block_no: u64, address: Address) -> AccountWithinBlock;
 ```
 
 ```rust
-pub fn get_account_with_storage(chain_id: Field, block_number: Field, address: Address, storage_key: Bytes32) -> StorageWithinBlock<1>;
+pub fn get_account_with_storage(chain_id: Field, block_number: u64, address: Address, storage_key: Bytes32) -> StorageWithinBlock<1>;
 ```
 
 ```rust
-pub fn get_receipt<...>(chain_id: Field, block_number: Field, tx_idx: Field, ...) -> TxReceiptWithinBlock<...>;
+pub fn get_receipt<...>(chain_id: Field, block_number: u64, tx_idx: Field, ...) -> TxReceiptWithinBlock;
+```
+
+```rust
+pub fn get_transaction<MAX_DATA_LEN, ...>(
+    chain_id: Field,
+    block_number: u64,
+    tx_idx: Field,
+    ...
+) -> TransactionWithinBlock<MAX_DATA_LEN>;
 ```
 
 ### Without oracles
@@ -61,12 +71,23 @@ pub fn verify_storage_values<N>(storage_root: Bytes32, proofs: [StorageProof; N]
 ```
 
 ```rust
-pub fn verify_receipt<...>(
+pub fn verify_receipt<MAX_RECEIPT_PROOF_LEN>(
     block_number: Field,
     tx_idx: Field,
+    tx_type: TxType,
     receipt: TxReceiptPartial,
-    receipt_proof: TxReceiptProof,
+    receipt_proof: ReceiptProof<MAX_RECEIPT_PROOF_LEN>,
     receipt_root: [u8; KEY_LENGTH]
+)
+```
+
+```rust
+pub fn verify_tx<MAX_DATA_LEN, MAX_PROOF_LEN>(
+    tx_idx: Field,
+    tx_type: TxType,
+    tx: TxPartial<MAX_DATA_LEN>,
+    tx_proof: TransactionProof<MAX_PROOF_LEN>,
+    tx_root: [u8; HASH_LENGTH]
 )
 ```
 
@@ -75,7 +96,7 @@ pub fn verify_receipt<...>(
 All the function in this library prove that the objects are contained within some block hash. We can't prove that this block hash is in fact a member of a canonical chain. This is user's responsibility. We provide Solidity [contract](../../contracts/src/EthereumHistoryVerifier.sol) that can prove block hash inclusion for the last 256 block on EVM and plan to maintain the Merkle Mountain Range on-chain in the future to allow for historical block hash inclusion proofs.
 
 > [!CAUTION]
->  Remember that it's your responsibility to prove block hash belongs to the chain. Otherwise - an attacker can generate valid proofs for non-existent blocks.
+> Remember that it's your responsibility to prove block hash belongs to the chain. Otherwise - an attacker can generate valid proofs for non-existent blocks.
 
 ## Package structure
 
@@ -85,10 +106,12 @@ All the function in this library prove that the objects are contained within som
     ├── receipt.nr
     ├── account.nr
     ├── account_with_storage.nr
-    ├── verifiers
+    ├── transaction.nr
+    └── verifiers
         ├── header.nr
         ├── receipt.nr
         ├── account.nr
+        ├── transaction.nr
         └── storage.nr
     ├── merkle_patricia_proofs
     └── rlp
@@ -119,7 +142,7 @@ type Bytes32 = [u8; 32];
 
 ```rust
 struct BlockHeaderPartial {
-    number: Field,
+    number: u64,
     hash: Bytes32,
     state_root: Bytes32,
     transactions_root: Bytes32,
@@ -129,7 +152,7 @@ struct BlockHeaderPartial {
 
 ```rust
 struct Account {
-    nonce: Field,
+    nonce: u64,
     balance: Field,
     storage_root: Bytes32,
     code_hash: Bytes32,
@@ -154,6 +177,26 @@ struct StorageWithinBlock<N> {
 ```rust
 struct TxReceiptWithinBlock {
     receipt: TxReceipt,
+    block_hash: Bytes32
+}
+```
+
+```rust
+struct TxPartial<MAX_DATA_LEN> {
+    nonce: u64,
+    gas_limit: u64,
+    to: Option<Address>,
+    value: U128,
+    data: BoundedVec<u8, MAX_DATA_LEN>,
+    v: u8,
+    r: Bytes32,
+    s: Bytes32,
+}
+```
+
+```rust
+struct TransactionWithinBlock<MAX_DATA_LEN> {
+    transaction: TxPartial<MAX_DATA_LEN>,
     block_hash: Bytes32
 }
 ```


### PR DESCRIPTION
This PR:
* Adds transactions to readme
* Rearranges `README` so that top level just mentions two sub-projects and the readme for noir-ethereum-history-api now lives within it's subfolder