### PR TITLE
Remove outdated comment

### DIFF
--- a/ethereum/circuits/lib/src/transaction.nr
+++ b/ethereum/circuits/lib/src/transaction.nr
@@ -58,7 +58,6 @@ impl<MAX_DATA_LEN> From<TxPartial> for ForeignCallTransaction<MAX_DATA_LEN> {
     fn from(tx: TxPartial<MAX_DATA_LEN>) -> Self {
         let mut data = [0; MAX_DATA_LEN];
 
-        // For some unclear reason (https://github.com/noir-lang/noir/issues/5011) - dynamic loop also works here, but we refrain from using it out of abundance of caution
         for i in 0..MAX_DATA_LEN {
             if (i < tx.data.len) {
                 data[i] = tx.data.storage[i];


### PR DESCRIPTION
This comment was a leftover from a moment, when we didn't understand what dynamic loop in Noir actually means.
Explanation: When using loop over data hardcoded somewhere else in files, Noir can read the length of that data and that makes a loop not dynamic.